### PR TITLE
Fix VC++ 14.x prereq gap + add passive "No team" indicator on unassigned profiles

### DIFF
--- a/Py4GW_Reforged_Launcher/launcher_core/prereqs.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/prereqs.py
@@ -593,6 +593,124 @@ def download_and_install_vcredist(arch: str, on_status: Callable[[str], None]) -
 
 
 # -----------------------------------------------------------------------------
+# Phase 2b -- Visual C++ 2015-2022 (14.x) Redistributable. RELAY 088: a real
+# user (n8unc, Discord) hit a GW.exe crash on injection, root-caused via his
+# own crash dump to a CRT version mismatch -- VCRUNTIME140.dll (bundled with
+# Py4GW.dll) vs. an old MSVCP140.dll already on his system. The VC++ 2013
+# check above doesn't cover this at all -- 2013 (v12.0) and 14.x (the
+# unified runtime line Microsoft has reused across every VS2015/2017/2019/
+# 2022 release) are separate CRT generations with independent installation
+# state. Fixed by installing the current unified redistributable.
+# -----------------------------------------------------------------------------
+
+# Current unified download links for the 14.x line -- confirmed live via a
+# direct HTTP check (not assumed): both resolve with a 301 redirect to a
+# real download.visualstudio.microsoft.com URL serving VC_redist.{arch}.exe
+# (200 OK, correct Content-Disposition filename, ~14MB x86 / ~26MB x64).
+VCREDIST_14_X86_URL = "https://aka.ms/vs/17/release/vc_redist.x86.exe"
+VCREDIST_14_X64_URL = "https://aka.ms/vs/17/release/vc_redist.x64.exe"
+
+
+def _check_vcredist14_runtimes_key(arch: str) -> Optional[str]:
+    """Same approach as _check_vcredist_runtimes_key above, but the unified
+    `14.0\\VC\\Runtimes\\{arch}` key Microsoft reuses across every VS2015+
+    release (one key covers VS2015 through the latest VS2022 update, not a
+    new key per release)."""
+    flag = winreg.KEY_WOW64_32KEY if arch == "x86" else winreg.KEY_WOW64_64KEY
+    try:
+        key = winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE, rf"SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\{arch}", 0,
+            winreg.KEY_READ | flag,
+        )
+        try:
+            version, _ = winreg.QueryValueEx(key, "Version")
+            return version
+        finally:
+            winreg.CloseKey(key)
+    except FileNotFoundError:
+        return None
+
+
+def _check_vcredist14_uninstall_key(arch: str) -> Optional[str]:
+    """Fallback check: scan the Uninstall registry entries for a
+    "Microsoft Visual C++ v14 Redistributable ({arch})" display name.
+
+    Marker string confirmed directly against this project's own dev machine
+    (not guessed/assumed) -- initial assumption was "2015-2022" in the name,
+    but the real installed entry reads "Microsoft Visual C++ v14
+    Redistributable (x64) - 14.51.36247".
+
+    Kept as a fallback for the same documented reason as
+    _check_vcredist_uninstall_key above (VC++ redistributable *updates*
+    have been known to leave the Runtimes key stale/deleted while the
+    software remains installed) -- on this specific dev machine the primary
+    Runtimes key actually resolved fine for both x86 and x64 once queried
+    with the correct explicit WOW64 view, so this fallback wasn't observed
+    firing here. Kept anyway for parity with the proven-necessary 2013
+    pattern rather than assumed unnecessary just because it didn't trigger
+    on one machine.
+    """
+    marker = f"visual c++ v14 redistributable ({arch})"
+    for hive, subkey in (
+        (winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"),
+        (winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"),
+    ):
+        try:
+            key = winreg.OpenKey(hive, subkey, 0, winreg.KEY_READ)
+        except FileNotFoundError:
+            continue
+        try:
+            i = 0
+            while True:
+                try:
+                    subkey_name = winreg.EnumKey(key, i)
+                except OSError:
+                    break
+                i += 1
+                try:
+                    entry = winreg.OpenKey(key, subkey_name)
+                    try:
+                        display_name, _ = winreg.QueryValueEx(entry, "DisplayName")
+                        display_version, _ = winreg.QueryValueEx(entry, "DisplayVersion")
+                    finally:
+                        winreg.CloseKey(entry)
+                except (FileNotFoundError, OSError):
+                    continue
+                if marker in display_name.lower():
+                    return display_version
+        finally:
+            winreg.CloseKey(key)
+    return None
+
+
+def check_vcredist14_prereq() -> VcRedistResult:
+    """Checks both the x86 and x64 Visual C++ 2015-2022 (14.x)
+    Redistributable -- the CRT line Py4GW.dll actually links against
+    (VCRUNTIME140.dll), separate from and not covered by the 2013 check
+    above. Reuses VcRedistResult/VcRedistStatus as-is rather than
+    duplicating an identical dataclass -- neither is 2013-specific in
+    shape, just in the values check_vcredist_prereq happens to fill them
+    with."""
+    x86_version = _check_vcredist14_runtimes_key("x86") or _check_vcredist14_uninstall_key("x86")
+    x64_version = _check_vcredist14_runtimes_key("x64") or _check_vcredist14_uninstall_key("x64")
+    return VcRedistResult(
+        x86_status=VcRedistStatus.OK if x86_version else VcRedistStatus.NOT_FOUND,
+        x64_status=VcRedistStatus.OK if x64_version else VcRedistStatus.NOT_FOUND,
+        x86_version=x86_version,
+        x64_version=x64_version,
+    )
+
+
+def download_and_install_vcredist14(arch: str, on_status: Callable[[str], None]) -> tuple[bool, str]:
+    """arch is "x86" or "x64". Same installer-run pattern as
+    download_and_install_vcredist above."""
+    url = VCREDIST_14_X86_URL if arch == "x86" else VCREDIST_14_X64_URL
+    return _download_and_run_signed_installer(
+        url, f"vcredist_14_{arch}.exe", VCREDIST_EXPECTED_SIGNER, args=[], on_status=on_status
+    )
+
+
+# -----------------------------------------------------------------------------
 # Phase 2 (continued) -- DirectX End-User Runtime (June 2010). Confirmed
 # necessary by Apo directly (Discord, 2026-04-05), linking Microsoft's own
 # download page and stating it's "necessary for install" -- a real, separate

--- a/Py4GW_Reforged_Launcher/launcher_core/test_prereqs.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/test_prereqs.py
@@ -1,0 +1,187 @@
+"""Unit tests for launcher_core/prereqs.py's VC++ 14.x check (RELAY 088).
+
+No committed test coverage existed for prereqs.py at all before this --
+verified via a direct search (find -iname "*test*") rather than assumed, since
+RELAY 088's own testing instruction ("extend existing prereq tests") turned
+out to be based on a premise that didn't hold. Writing real coverage here
+instead of just the manual on-machine check the entry also asked for, since
+mocking winreg is safe (no risk of touching/uninstalling anything on a real
+machine to exercise the "not found" branch) and this is exactly the kind of
+registry-parsing logic that's easy to silently break later.
+
+Run: .venv\\Scripts\\python.exe -m unittest launcher_core.test_prereqs -v
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from launcher_core import prereqs
+
+
+class FakeWinregModule:
+    """Minimal stand-in for the winreg module, driven by a dict of
+    {(hive, subkey): {value_name: value}} for OpenKey/QueryValueEx, and a
+    dict of {(hive, subkey): [(display_name, display_version), ...]} for the
+    Uninstall-scan EnumKey/QueryValueEx path. Missing keys raise
+    FileNotFoundError, matching the real winreg module's behavior."""
+
+    KEY_READ = 0x20019
+    KEY_WOW64_32KEY = 0x0200
+    KEY_WOW64_64KEY = 0x0100
+    HKEY_LOCAL_MACHINE = object()
+
+    def __init__(self, runtimes_keys=None, uninstall_entries=None):
+        self._runtimes_keys = runtimes_keys or {}
+        self._uninstall_entries = uninstall_entries or {}
+
+    def OpenKey(self, hive, subkey, *_args, **_kwargs):
+        # Runtimes-key path: subkey ends in a real value dict.
+        if subkey in self._runtimes_keys:
+            return ("runtimes", subkey)
+        # Uninstall-scan path: subkey is one of the two Uninstall roots.
+        if subkey in self._uninstall_entries:
+            return ("uninstall", subkey)
+        raise FileNotFoundError(subkey)
+
+    def QueryValueEx(self, key_handle, name):
+        kind, subkey = key_handle
+        if kind == "runtimes":
+            values = self._runtimes_keys[subkey]
+            if name not in values:
+                raise FileNotFoundError(name)
+            return values[name], 1
+        # Uninstall entry sub-key: key_handle here is actually the specific
+        # entry sub-key handle produced by EnumKey+OpenKey below.
+        entry = key_handle
+        if entry[0] != "entry":
+            raise FileNotFoundError(name)
+        display_name, display_version = entry[1]
+        if name == "DisplayName":
+            return display_name, 1
+        if name == "DisplayVersion":
+            return display_version, 1
+        raise FileNotFoundError(name)
+
+    def EnumKey(self, key_handle, index):
+        kind, subkey = key_handle
+        entries = self._uninstall_entries.get(subkey, [])
+        if index >= len(entries):
+            raise OSError("no more items")
+        return f"entry_{index}"
+
+    def CloseKey(self, _key_handle):
+        pass
+
+    # OpenKey is called twice per Uninstall entry in the real code path
+    # (once for the root, once per enumerated sub-key) -- route the second
+    # call (sub-key open) to the right fake "entry" handle.
+    def _open_entry(self, subkey, subkey_name):
+        entries = self._uninstall_entries.get(subkey, [])
+        idx = int(subkey_name.rsplit("_", 1)[1])
+        return ("entry", entries[idx])
+
+
+def _make_fake_winreg(runtimes_keys=None, uninstall_entries=None):
+    fake = FakeWinregModule(runtimes_keys=runtimes_keys, uninstall_entries=uninstall_entries)
+
+    real_open_key = fake.OpenKey
+
+    def open_key(hive_or_parent, subkey, *args, **kwargs):
+        # The real code's second OpenKey call per Uninstall entry passes the
+        # already-opened root's own key handle as the first arg (not a real
+        # HKEY constant) plus the short enumerated sub-key name -- route
+        # that to _open_entry instead of the root-level lookup.
+        if isinstance(hive_or_parent, tuple) and hive_or_parent[0] == "uninstall":
+            return fake._open_entry(hive_or_parent[1], subkey)
+        return real_open_key(hive_or_parent, subkey, *args, **kwargs)
+
+    fake.OpenKey = open_key
+    return fake
+
+
+class CheckVcRedist14PrereqTests(unittest.TestCase):
+    def test_runtimes_key_found_both_archs(self):
+        """Both Runtimes keys present -- the common/expected case."""
+        fake = _make_fake_winreg(
+            runtimes_keys={
+                r"SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x86": {"Version": "v14.51.36247.00"},
+                r"SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64": {"Version": "v14.51.36247.00"},
+            },
+        )
+        with patch.object(prereqs, "winreg", fake):
+            result = prereqs.check_vcredist14_prereq()
+        self.assertEqual(result.x86_status, prereqs.VcRedistStatus.OK)
+        self.assertEqual(result.x64_status, prereqs.VcRedistStatus.OK)
+        self.assertEqual(result.x86_version, "v14.51.36247.00")
+        self.assertEqual(result.x64_version, "v14.51.36247.00")
+        self.assertTrue(result.is_ok)
+
+    def test_runtimes_key_missing_falls_back_to_uninstall_scan(self):
+        """Hypothetical/precedent-based scenario, not one actually observed
+        on this project's own dev machine (there, both archs' Runtimes keys
+        resolved fine once queried with the correct explicit WOW64 view --
+        an earlier ad-hoc check without that view flag falsely suggested
+        x86 was missing, corrected before landing this). Still worth
+        covering: the 2013 check's own docstring documents Microsoft VC++
+        redistributable *updates* leaving the Runtimes key stale/deleted
+        while the software remains installed, and this fallback exists for
+        the same reason -- verify it actually works, not just that it's
+        present."""
+        fake = _make_fake_winreg(
+            runtimes_keys={
+                r"SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64": {"Version": "v14.51.36247.00"},
+            },
+            uninstall_entries={
+                r"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall": [
+                    ("Microsoft Visual C++ v14 Redistributable (x86) - 14.51.36247", "14.51.36247.0"),
+                ],
+                r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall": [],
+            },
+        )
+        with patch.object(prereqs, "winreg", fake):
+            result = prereqs.check_vcredist14_prereq()
+        self.assertEqual(result.x86_status, prereqs.VcRedistStatus.OK)
+        self.assertEqual(result.x86_version, "14.51.36247.0")
+        self.assertEqual(result.x64_status, prereqs.VcRedistStatus.OK)
+
+    def test_neither_present_reports_not_found(self):
+        fake = _make_fake_winreg()
+        with patch.object(prereqs, "winreg", fake):
+            result = prereqs.check_vcredist14_prereq()
+        self.assertEqual(result.x86_status, prereqs.VcRedistStatus.NOT_FOUND)
+        self.assertEqual(result.x64_status, prereqs.VcRedistStatus.NOT_FOUND)
+        self.assertFalse(result.is_ok)
+        self.assertIsNone(result.x86_version)
+        self.assertIsNone(result.x64_version)
+
+    def test_uninstall_scan_marker_is_case_insensitive_and_matches_real_wording(self):
+        """The marker string was corrected against this project's own real
+        machine (RELAY 088) -- "v14 Redistributable", not the initially
+        assumed "2015-2022 Redistributable". Confirms the real observed
+        display-name format actually matches."""
+        fake = _make_fake_winreg(
+            uninstall_entries={
+                r"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall": [
+                    ("MICROSOFT VISUAL C++ V14 REDISTRIBUTABLE (X64) - 14.51.36247", "14.51.36247.0"),
+                ],
+                r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall": [],
+            },
+        )
+        with patch.object(prereqs, "winreg", fake):
+            result = prereqs.check_vcredist14_prereq()
+        self.assertEqual(result.x64_status, prereqs.VcRedistStatus.OK)
+
+    def test_urls_are_the_unified_14x_line_not_2013(self):
+        """Guards against ever accidentally pointing the 14.x install
+        button at the 2013 URLs (or vice versa) -- the two constants must
+        stay distinct."""
+        self.assertNotEqual(prereqs.VCREDIST_14_X86_URL, prereqs.VCREDIST_2013_X86_URL)
+        self.assertNotEqual(prereqs.VCREDIST_14_X64_URL, prereqs.VCREDIST_2013_X64_URL)
+        self.assertIn("vc_redist.x86.exe", prereqs.VCREDIST_14_X86_URL)
+        self.assertIn("vc_redist.x64.exe", prereqs.VCREDIST_14_X64_URL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Py4GW_Reforged_Launcher/pywebview_shell/bridge.py
+++ b/Py4GW_Reforged_Launcher/pywebview_shell/bridge.py
@@ -546,6 +546,7 @@ class ShellBridge:
     def _run_prereq_checks(self) -> None:
         python_result = prereqs.check_python_prereq()
         vcredist_result = prereqs.check_vcredist_prereq()
+        vcredist14_result = prereqs.check_vcredist14_prereq()
         directx_result = prereqs.check_directx_runtime_prereq()
         self.push_event(
             "prereqs_result",
@@ -559,15 +560,26 @@ class ShellBridge:
                     "is_ok": vcredist_result.x64_status == prereqs.VcRedistStatus.OK,
                     "diagnostic_text": f"version {vcredist_result.x64_version}" if vcredist_result.x64_version else "not found",
                 },
+                # RELAY 088: separate CRT generation from the 2013 pair above --
+                # Py4GW.dll links against this one (VCRUNTIME140.dll), not 2013.
+                "vcredist14_x86": {
+                    "is_ok": vcredist14_result.x86_status == prereqs.VcRedistStatus.OK,
+                    "diagnostic_text": f"version {vcredist14_result.x86_version}" if vcredist14_result.x86_version else "not found",
+                },
+                "vcredist14_x64": {
+                    "is_ok": vcredist14_result.x64_status == prereqs.VcRedistStatus.OK,
+                    "diagnostic_text": f"version {vcredist14_result.x64_version}" if vcredist14_result.x64_version else "not found",
+                },
                 "directx_runtime": {"is_ok": directx_result.is_ok, "diagnostic_text": directx_result.diagnostic_text},
             },
         )
 
     def install_prereq(self, component: str) -> dict:
         """component is "python"/"vcredist_x86"/"vcredist_x64"/
-        "directx_runtime". Rejects a second concurrent install -- the real
-        user-facing prevention is the UI disabling the button while one's
-        in flight, this is just the server-side guard behind it."""
+        "vcredist14_x86"/"vcredist14_x64"/"directx_runtime". Rejects a second
+        concurrent install -- the real user-facing prevention is the UI
+        disabling the button while one's in flight, this is just the
+        server-side guard behind it."""
         with self._prereq_install_lock:
             if self._prereq_install_in_progress is not None:
                 return {"ok": False, "error": "An install is already in progress"}
@@ -585,6 +597,10 @@ class ShellBridge:
             success, message = prereqs.download_and_install_vcredist("x86", on_status)
         elif component == "vcredist_x64":
             success, message = prereqs.download_and_install_vcredist("x64", on_status)
+        elif component == "vcredist14_x86":
+            success, message = prereqs.download_and_install_vcredist14("x86", on_status)
+        elif component == "vcredist14_x64":
+            success, message = prereqs.download_and_install_vcredist14("x64", on_status)
         elif component == "directx_runtime":
             success, message = prereqs.download_and_install_directx_runtime(on_status)
         else:

--- a/Py4GW_Reforged_Launcher/pywebview_shell/web/app.js
+++ b/Py4GW_Reforged_Launcher/pywebview_shell/web/app.js
@@ -296,7 +296,14 @@ function applyCardLaunchVisual(card, p) {
       // at rest. Now that card order itself reflects position (084's Added-
       // order default), this slot has nothing meaningful to show at idle;
       // deliberately left empty rather than replaced with anything else.
-      sub.textContent = "";
+      // RELAY 089: except one real signal worth surfacing here -- a profile
+      // with no team membership at all, same "No team" definition the
+      // search dropdown's grouping already uses (~line 1808), not a second
+      // one. ALL-view only (a team-scoped view can't contain an orphaned
+      // profile by definition) and idle-only (every other branch above
+      // already returns before reaching here, so this never overwrites a
+      // real launch/queued/running/error status).
+      sub.textContent = (activeTeamId === "ALL" && (p.team_ids || []).length === 0) ? "No team" : "";
       sub.removeAttribute("data-tooltip");
     }
     action.innerHTML = "&#9654; Launch";

--- a/Py4GW_Reforged_Launcher/pywebview_shell/web/app.js
+++ b/Py4GW_Reforged_Launcher/pywebview_shell/web/app.js
@@ -1224,15 +1224,20 @@ async function loadLauncherVersion() {
 // _show_prereq_install_confirm_popup, onto push_event instead of that
 // class's polling design (see bridge.py's check_prereqs/install_prereq).
 
-const PREREQ_COMPONENTS = ["python", "vcredist_x86", "vcredist_x64", "directx_runtime"];
+const PREREQ_COMPONENTS = ["python", "vcredist_x86", "vcredist_x64", "vcredist14_x86", "vcredist14_x64", "directx_runtime"];
 // Labels/URLs mirrored from launcher_core/prereqs.py's own real constants
 // (PYTHON_DOWNLOAD_URL, VCREDIST_2013_X86_URL, VCREDIST_2013_X64_URL,
-// DIRECTX_RUNTIME_DOWNLOAD_URL) -- JS can't import that module directly,
-// so keep these in sync by hand if the Python side's URLs ever change.
+// VCREDIST_14_X86_URL, VCREDIST_14_X64_URL, DIRECTX_RUNTIME_DOWNLOAD_URL) --
+// JS can't import that module directly, so keep these in sync by hand if
+// the Python side's URLs ever change.
 const PREREQ_INFO = {
   python: { label: "Python 3.13.0 (32-bit)", url: "https://www.python.org/ftp/python/3.13.0/python-3.13.0.exe" },
-  vcredist_x86: { label: "VC++ Redistributable (x86)", url: "https://aka.ms/highdpimfc2013x86enu" },
-  vcredist_x64: { label: "VC++ Redistributable (x64)", url: "https://aka.ms/highdpimfc2013x64enu" },
+  vcredist_x86: { label: "VC++ 2013 Redistributable (x86)", url: "https://aka.ms/highdpimfc2013x86enu" },
+  vcredist_x64: { label: "VC++ 2013 Redistributable (x64)", url: "https://aka.ms/highdpimfc2013x64enu" },
+  // RELAY 088: separate CRT generation from the 2013 pair above -- Py4GW.dll
+  // links against this one (VCRUNTIME140.dll), not 2013.
+  vcredist14_x86: { label: "VC++ 2015-2022 Redistributable (x86)", url: "https://aka.ms/vs/17/release/vc_redist.x86.exe" },
+  vcredist14_x64: { label: "VC++ 2015-2022 Redistributable (x64)", url: "https://aka.ms/vs/17/release/vc_redist.x64.exe" },
   directx_runtime: {
     label: "DirectX End-User Runtime",
     url: "https://download.microsoft.com/download/8/4/a/84a35bf1-dafe-4ae8-82af-ad2ae20b6b14/directx_Jun2010_redist.exe",

--- a/Py4GW_Reforged_Launcher/pywebview_shell/web/index.html
+++ b/Py4GW_Reforged_Launcher/pywebview_shell/web/index.html
@@ -206,17 +206,31 @@
             </div>
           </div>
           <div class="prereq-row" id="prereq-row-vcredist_x86">
-            <span class="prereq-label">VC++ Redistributable (x86)</span>
+            <span class="prereq-label">VC++ 2013 Redistributable (x86)</span>
             <div class="prereq-status-row">
               <span class="prereq-status" id="prereq-status-vcredist_x86">Checking...</span>
               <button class="small-btn" id="prereq-install-vcredist_x86" style="display:none" onclick="onPrereqInstallClick('vcredist_x86')">Install now</button>
             </div>
           </div>
           <div class="prereq-row" id="prereq-row-vcredist_x64">
-            <span class="prereq-label">VC++ Redistributable (x64)</span>
+            <span class="prereq-label">VC++ 2013 Redistributable (x64)</span>
             <div class="prereq-status-row">
               <span class="prereq-status" id="prereq-status-vcredist_x64">Checking...</span>
               <button class="small-btn" id="prereq-install-vcredist_x64" style="display:none" onclick="onPrereqInstallClick('vcredist_x64')">Install now</button>
+            </div>
+          </div>
+          <div class="prereq-row" id="prereq-row-vcredist14_x86">
+            <span class="prereq-label">VC++ 2015-2022 Redistributable (x86)</span>
+            <div class="prereq-status-row">
+              <span class="prereq-status" id="prereq-status-vcredist14_x86">Checking...</span>
+              <button class="small-btn" id="prereq-install-vcredist14_x86" style="display:none" onclick="onPrereqInstallClick('vcredist14_x86')">Install now</button>
+            </div>
+          </div>
+          <div class="prereq-row" id="prereq-row-vcredist14_x64">
+            <span class="prereq-label">VC++ 2015-2022 Redistributable (x64)</span>
+            <div class="prereq-status-row">
+              <span class="prereq-status" id="prereq-status-vcredist14_x64">Checking...</span>
+              <button class="small-btn" id="prereq-install-vcredist14_x64" style="display:none" onclick="onPrereqInstallClick('vcredist14_x64')">Install now</button>
             </div>
           </div>
           <div class="prereq-row" id="prereq-row-directx_runtime">


### PR DESCRIPTION
## Summary

Two independent fixes, bundled together since they're both small and from the same feedback round:

1. **Prereq checker was missing VC++ 2015-2022 (14.x) entirely.** A user (n8unc, Discord) hit a `GW.exe` crash on injection, root-caused via their own crash dump to a CRT mismatch — `VCRUNTIME140.dll` (bundled with `Py4GW.dll`) vs. an old `MSVCP140.dll` already on the system. The existing prereq checker only ever validated VC++ 2013 (v12.0); there was no check for the 14.x line at all. Fixed to mirror the existing 2013 check's pattern (Runtimes-key first, Uninstall-scan fallback), wired through the same install flow as the other prereqs.

2. **Orphaned profiles (no team) were invisible in the ALL view.** Feedback flagged that "Add Team" wasn't obvious enough — some users didn't realize ALL isn't a real team and never created one. Added a passive "No team" label on any profile card with no team membership, ALL view only, idle state only (never overwrites a real launch/queued/running/error status). Reuses the same "No team" grouping definition the search dropdown already used, rather than a new one.

## Notes

- The VC++ 14.x Uninstall-scan marker string was verified against a real installed runtime rather than guessed — it's `"Microsoft Visual C++ v14 Redistributable (x86/x64)"`, not the "2015-2022" wording that seemed more obvious at first glance.
- Added test coverage for the new prereq check (`launcher_core/test_prereqs.py`) — there wasn't any for the prereqs module before this.
- Both changes tested live in the running app, not just unit-tested.

## Test plan

- [x] `launcher_core` + `pywebview_shell` test suites green (66/66)
- [x] Live-tested: Setup tab shows both new VC++ 14.x rows, correctly detecting an installed runtime
- [x] Live-tested: a profile with no team membership shows "No team" in the ALL view; team-assigned profiles don't