### PR TITLE
gMod: graceful-skip instead of hard-failing the whole launch on an unresolved DLL path

### DIFF
--- a/Py4GW_Reforged_Launcher/launcher_core/gw1_launch.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/gw1_launch.py
@@ -253,6 +253,49 @@ def _log(log: list, message: str) -> None:
         on_message(message)
 
 
+def _resolve_gmod_launch_decision(profile: GameProfile, gmod_injection_enabled: bool, log: list) -> bool:
+    """RELAY 091: decides whether gMod injection should actually be attempted
+    this launch. Used to be a hard gate that failed the whole launch (even
+    Py4GW) if gmod_dll_path was unresolved -- gMod is opt-in/auxiliary,
+    unlike Py4GW (the equivalent check just above this call site, deliberately
+    left as a hard fail, unchanged), so a missing gMod path shouldn't block
+    the client from launching at all.
+
+    Pulled out as its own function specifically so it's unit-testable without
+    mocking the surrounding Win32 launch pipeline (CreateProcessW etc.) --
+    this repo had no test coverage for gw1_launch.py at all before this,
+    verified via a real search, not assumed.
+
+    If the saved path is missing/stale, re-runs mod_root.find_dll_under_mod_root
+    once before giving up -- auto-detect (RELAY 083) only ever runs at
+    profile creation/import time, so a profile made before the gMod DLL
+    existed on disk (or whose auto-detect found 0/2+ matches back then) would
+    otherwise stay permanently unresolved. If that resolves it, mutates
+    profile.gmod_dll_path in place -- session-only self-heal (helps a same-
+    session retry reuse the same in-memory GameProfile, since gw1_launch.py
+    has no accounts_store/disk-persistence responsibility of its own and
+    bridge.py's _run_launch doesn't save profiles after a launch attempt);
+    deliberately NOT written to accounts.json here, since that would need new
+    plumbing (LaunchResult would need a new field, bridge.py would need to
+    act on it) for a fix whose whole point is "gMod is auxiliary, keep this
+    minimal." Explicit decision, not an oversight -- if this needs to survive
+    an app restart later, that's a separate, bigger follow-up.
+    """
+    if not (profile.gmod_enabled and gmod_injection_enabled):
+        return False
+    if profile.gmod_dll_path and os.path.exists(profile.gmod_dll_path):
+        return True
+
+    redetected = mod_root.find_dll_under_mod_root("gMod.dll")
+    if redetected:
+        profile.gmod_dll_path = redetected
+        _log(log, f"gmod_dll_path was unresolved; auto-detected: {redetected}")
+        return True
+
+    _log(log, "gMod path not set or not found -- launching without gMod injection")
+    return False
+
+
 def _get_process_module_base(process_handle: int) -> Optional[int]:
     pbi = PROCESS_BASIC_INFORMATION()
     return_length = ctypes.c_ulong(0)
@@ -837,11 +880,7 @@ def launch_py4gw_profile(
     ):
         return LaunchResult(False, None, f"py4gw_dll_path not found: {profile.py4gw_dll_path!r}", log)
 
-    if (
-        profile.gmod_enabled and gmod_injection_enabled
-        and (not profile.gmod_dll_path or not os.path.exists(profile.gmod_dll_path))
-    ):
-        return LaunchResult(False, None, f"gmod_dll_path not found: {profile.gmod_dll_path!r}", log)
+    will_inject_gmod = _resolve_gmod_launch_decision(profile, gmod_injection_enabled, log)
 
     command_line = f'"{profile.executable_path}"'
     if profile.windowed_mode_enabled:
@@ -891,7 +930,7 @@ def launch_py4gw_profile(
     # very early (the opposite timing from Py4GW's post-window injection
     # below). _inject_dll uses CreateRemoteThread, which is independent of the
     # primary thread's own suspended state, so this is safe against it.
-    if profile.gmod_enabled and gmod_injection_enabled:
+    if will_inject_gmod:
         try:
             per_profile_gmod_dll = _prepare_per_profile_gmod_folder(profile)
         except Exception as e:
@@ -902,6 +941,14 @@ def launch_py4gw_profile(
             return _abort("gMod DLL injection failed")
 
         _log(log, "gMod DLL injection reported success")
+    elif profile.gmod_enabled and gmod_injection_enabled:
+        # RELAY 091: enabled at both levels, but the path never resolved even
+        # after _resolve_gmod_launch_decision's auto-detect retry -- that
+        # function already logged the specific reason at the point of
+        # discovery, so there's nothing more useful to add here (the old
+        # single else-branch message below would be misleading in this case:
+        # gMod isn't "disabled", it's enabled with an unresolved path).
+        pass
     elif profile.gmod_enabled and not gmod_injection_enabled:
         _log(log, "gMod injection globally disabled (App Settings) -- launching without it")
     else:

--- a/Py4GW_Reforged_Launcher/launcher_core/test_gw1_launch.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/test_gw1_launch.py
@@ -1,0 +1,116 @@
+"""Unit tests for launcher_core/gw1_launch.py's gMod graceful-skip fix (RELAY 091).
+
+No committed test coverage existed for gw1_launch.py at all before this --
+verified via a real search, not assumed (same situation RELAY 088 hit for
+prereqs.py). The full launch pipeline is heavily Win32-coupled
+(CreateProcessW, CreateRemoteThread, window polling), not something to mock
+wholesale for a scope this small -- _resolve_gmod_launch_decision was pulled
+out specifically so the actual decision logic is testable in isolation.
+
+One regression test at the full launch_py4gw_profile level confirms the
+py4gw_dll_path hard-fail (deliberately unchanged by this entry) still fires
+before any process gets created -- that path doesn't touch Win32 either,
+since it returns before CreateProcessW.
+
+Run: .venv\\Scripts\\python.exe -m unittest launcher_core.test_gw1_launch -v
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from launcher_core import gw1_launch
+from launcher_core.gw1_launch import _resolve_gmod_launch_decision, launch_py4gw_profile
+from launcher_core.profile import GameProfile
+
+
+class ResolveGmodLaunchDecisionTests(unittest.TestCase):
+    def setUp(self):
+        self.log: list = []
+
+    def test_gmod_disabled_on_profile_returns_false_no_autodetect(self):
+        profile = GameProfile(gmod_enabled=False, gmod_dll_path="")
+        with patch.object(gw1_launch.mod_root, "find_dll_under_mod_root") as mock_detect:
+            result = _resolve_gmod_launch_decision(profile, gmod_injection_enabled=True, log=self.log)
+        self.assertFalse(result)
+        mock_detect.assert_not_called()
+
+    def test_gmod_disabled_globally_returns_false_no_autodetect(self):
+        profile = GameProfile(gmod_enabled=True, gmod_dll_path="")
+        with patch.object(gw1_launch.mod_root, "find_dll_under_mod_root") as mock_detect:
+            result = _resolve_gmod_launch_decision(profile, gmod_injection_enabled=False, log=self.log)
+        self.assertFalse(result)
+        mock_detect.assert_not_called()
+
+    def test_path_already_valid_returns_true_no_autodetect(self):
+        with tempfile.NamedTemporaryFile(suffix=".dll", delete=False) as f:
+            real_path = f.name
+        try:
+            profile = GameProfile(gmod_enabled=True, gmod_dll_path=real_path)
+            with patch.object(gw1_launch.mod_root, "find_dll_under_mod_root") as mock_detect:
+                result = _resolve_gmod_launch_decision(profile, gmod_injection_enabled=True, log=self.log)
+            self.assertTrue(result)
+            mock_detect.assert_not_called()
+        finally:
+            Path(real_path).unlink()
+
+    def test_missing_path_autodetect_resolves_it_mutates_profile_and_logs(self):
+        profile = GameProfile(gmod_enabled=True, gmod_dll_path="")
+        with patch.object(gw1_launch.mod_root, "find_dll_under_mod_root", return_value="C:/found/gMod.dll") as mock_detect:
+            result = _resolve_gmod_launch_decision(profile, gmod_injection_enabled=True, log=self.log)
+        self.assertTrue(result)
+        mock_detect.assert_called_once_with("gMod.dll")
+        self.assertEqual(profile.gmod_dll_path, "C:/found/gMod.dll")
+        self.assertTrue(any("auto-detected" in line for line in self.log))
+
+    def test_missing_path_autodetect_still_fails_graceful_skip_not_hard_fail(self):
+        """The core RELAY 091 behavior change: this used to hard-fail the
+        whole launch (LaunchResult(False, ...)) -- now it's just a decision
+        of False, with a clear log line, so the caller can proceed without
+        gMod instead of aborting Py4GW injection too."""
+        profile = GameProfile(gmod_enabled=True, gmod_dll_path="")
+        with patch.object(gw1_launch.mod_root, "find_dll_under_mod_root", return_value=""):
+            result = _resolve_gmod_launch_decision(profile, gmod_injection_enabled=True, log=self.log)
+        self.assertFalse(result)
+        self.assertEqual(profile.gmod_dll_path, "")  # not persisted from a failed redetect
+        self.assertTrue(any("launching without gMod injection" in line for line in self.log))
+
+    def test_stale_nonexistent_path_treated_same_as_empty(self):
+        """A saved path that doesn't exist on disk anymore (not just an
+        empty string) should also trigger the redetect attempt."""
+        profile = GameProfile(gmod_enabled=True, gmod_dll_path="C:/does/not/exist/gMod.dll")
+        with patch.object(gw1_launch.mod_root, "find_dll_under_mod_root", return_value="C:/found/gMod.dll") as mock_detect:
+            result = _resolve_gmod_launch_decision(profile, gmod_injection_enabled=True, log=self.log)
+        self.assertTrue(result)
+        mock_detect.assert_called_once()
+        self.assertEqual(profile.gmod_dll_path, "C:/found/gMod.dll")
+
+
+class Py4GwHardFailRegressionTest(unittest.TestCase):
+    """RELAY 091 explicitly scoped gMod-only -- confirms the identical
+    py4gw_dll_path check just above it is genuinely untouched, not just
+    read-and-assumed unchanged."""
+
+    def test_py4gw_path_missing_still_hard_fails_before_any_process_created(self):
+        with tempfile.NamedTemporaryFile(suffix=".exe", delete=False) as f:
+            fake_exe = f.name
+        try:
+            profile = GameProfile(
+                executable_path=fake_exe,
+                py4gw_enabled=True,
+                py4gw_dll_path="C:/does/not/exist/Py4GW.dll",
+                gmod_enabled=False,
+            )
+            result = launch_py4gw_profile(profile, py4gw_injection_enabled=True, gmod_injection_enabled=True)
+        finally:
+            Path(fake_exe).unlink()
+
+        self.assertFalse(result.success)
+        self.assertIn("py4gw_dll_path not found", result.error or "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Reported by mark (Discord): "lol Launch all fails on gmod injection after the first one, there' I broke it." Confirmed: a profile with gMod injection enabled but `gmod_dll_path` unresolved (empty or pointing at a file that no longer exists) aborted the **entire** launch before the process was even created — including Py4GW injection, even though that path was perfectly valid.

gMod is opt-in/auxiliary. Py4GW is this launcher's core purpose, so the equivalent check for a missing Py4GW path is deliberately left as a hard fail, unchanged — but a missing gMod path shouldn't block the client from launching at all.

## What changed

- Auto-detect for the gMod DLL already existed (`mod_root.find_dll_under_mod_root`), but only ever ran at profile creation/import time. A profile whose lookup found zero or multiple matches back then stayed permanently unresolved on every future launch.
- Now, if the saved path is missing or stale, launch re-runs auto-detect once before giving up.
- If that still can't resolve it: instead of failing the launch, it logs a clear reason ("gMod path not set or not found — launching without gMod injection") and proceeds without gMod, same as if gMod were disabled for that profile.
- The Py4GW path check is untouched.

## Notes

- Pulled the decision logic into its own function (`_resolve_gmod_launch_decision`) specifically so it's unit-testable without mocking the full Win32 launch pipeline — there wasn't any test coverage for this file before.
- A resolved auto-detect is used for the current launch and kept in memory for the rest of the session (helps a retry on the same profile without restarting the app), but isn't written back to `accounts.json` — that would need more plumbing than this fix's scope, noted as a deliberate call rather than an oversight.

## Test plan

- [x] New unit tests covering: gMod disabled at profile/global level, path already valid, redetect succeeds, redetect still fails (graceful skip, not hard fail), stale vs. empty path treated the same
- [x] Regression test confirming the Py4GW hard-fail is genuinely unchanged
- [x] Live-checked against this real repo (not mocked): a broken profile's path correctly auto-detects to the real `Addons/gMod.dll` on disk
- [x] Full test suite green