### PR TITLE
Fix Loot Manager dye and rarity preset handling

### DIFF
--- a/Py4GWCoreLib/py4gwcorelib_src/Lootconfig_src.py
+++ b/Py4GWCoreLib/py4gwcorelib_src/Lootconfig_src.py
@@ -807,6 +807,21 @@ class LootConfig:
             if self.IsBlacklisted(model_id):
                 continue
 
+            # Dye vials all share one model ID, so their pickup decision must
+            # use the embedded dye colour rather than the normal model-ID list.
+            if model_id == ModelID.Vial_Of_Dye.value:
+                try:
+                    dye_color = Item.Dye.GetInfo(item_id).dye1.ToInt()
+                except Exception:
+                    dye_color = None
+
+                if dye_color is not None:
+                    if self.IsDyeBlacklisted(dye_color):
+                        continue
+                    if self.IsDyeWhitelisted(dye_color):
+                        pick_up_array.append(agent_id)
+                        continue
+
             # --- Whitelists ---
             if self.IsItemIDWhitelisted(item_id):
                 pick_up_array.append(agent_id)

--- a/Widgets/Data/modelid_drop_data.json
+++ b/Widgets/Data/modelid_drop_data.json
@@ -31,6 +31,8 @@
   {"name": "Champagne Popper", "model_id": "ModelID.Champagne_Popper", "group": "Party", "subgroup": "1 Points", "drop_info": "Anniversary Celebration & Wayfarer's Reverie"},
   {"name": "Sparkler", "model_id": "ModelID.Sparkler", "group": "Party", "subgroup": "1 Points", "drop_info": "Anniversary Celebration & Wayfarer's Reverie"},
   {"name": "Snowman Summoner", "model_id": "ModelID.Snowman_Summoner", "group": "Party", "subgroup": "1 Points", "drop_info": "Wintersday & Chest of Wintersday Past"},
+  {"name": "Frosty Tonic", "model_id": "ModelID.Frosty_Tonic", "group": "Party", "subgroup": "2 Points", "drop_info": "Winterday"},
+  {"name": "Mischievous Tonic", "model_id": "ModelID.Mischievious_Tonic", "group": "Party", "subgroup": "2 Points", "drop_info": "Winterday"},
   {"name": "El Mischievious Tonic", "model_id": "ModelID.El_Mischievious_Tonic", "group": "Party", "subgroup": "2 Points", "drop_info": "Winterday"},
   {"name": "El Yuletide Tonic", "model_id": "ModelID.El_Yuletide_Tonic", "group": "Party", "subgroup": "2 Points", "drop_info": "Wintersday & Chest of Wintersday Past"},
   {"name": "Party Beacon", "model_id": "ModelID.Party_Beacon", "group": "Party", "subgroup": "50 Points", "drop_info": "Anniversary Celebration"},

--- a/Widgets/Guild Wars/Items & Loot/LootManager.py
+++ b/Widgets/Guild Wars/Items & Loot/LootManager.py
@@ -296,12 +296,15 @@ def load_loot_config_from(path: str):
 
     # Apply saved rarity filters
     loot_filter_singleton.SetProperties(
-        loot_whites=rarity.get("white", False),
-        loot_blues=rarity.get("blue", False),
-        loot_purples=rarity.get("purple", False),
-        loot_golds=rarity.get("gold", False),
-        loot_greens=rarity.get("green", False),
-        loot_gold_coins=rarity.get("gold_coins", False),
+        # Exported presets use the ``loot_*`` field names.  Accept the old
+        # short names as a fallback so existing manually-created presets keep
+        # working too.
+        loot_whites=rarity.get("loot_whites", rarity.get("white", False)),
+        loot_blues=rarity.get("loot_blues", rarity.get("blue", False)),
+        loot_purples=rarity.get("loot_purples", rarity.get("purple", False)),
+        loot_golds=rarity.get("loot_golds", rarity.get("gold", False)),
+        loot_greens=rarity.get("loot_greens", rarity.get("green", False)),
+        loot_gold_coins=rarity.get("loot_gold_coins", rarity.get("gold_coins", False)),
     )
 
     # Persist changes to avoid core loop overwrite


### PR DESCRIPTION
## Summary
- honor selected dye colors when evaluating dye vial drops
- add Frosty and Mischievous Tonics to the Winterday Loot Manager catalog
- restore saved rarity filters from exported Loot Manager presets, while retaining compatibility with legacy short field names

## Validation
- Confirmed in game that a selected purple dye is picked up.
- Confirmed that saved rarity selections remain checked after reloading a preset.