### PR TITLE
Fix OutpostRunnerV2 path overlay freeze

### DIFF
--- a/Widgets/Automation/Bots/Runners/OutpostRunnerV2.py
+++ b/Widgets/Automation/Bots/Runners/OutpostRunnerV2.py
@@ -56,7 +56,7 @@ bot = Botting(BotSettings.BOT_NAME,
             upkeep_honeycomb_restock=10,
             upkeep_honeycomb_active=False,
             upkeep_hero_ai_active=True,
-            config_draw_path=True)
+            config_draw_path=False)
 # endregion
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- disable OutpostRunnerV2's 3D path overlay
- retain the existing runner UI, routing, FSM, build, and movement behavior

## Why
On the affected Reforged setup, rendering the Botting 3D path overlay (UI.DrawPath through DXOverlay.FindZ / DrawLine3D) freezes the Guild Wars client immediately after movement begins. The otherwise identical runner completes normally when path drawing is disabled.

## Verification
- reproduced the freeze with the full runner and a controlled Botting UI probe while path drawing was enabled
- confirmed the same probe succeeds with only config_draw_path=False`n- completed a fresh-process, end-to-end OutpostRunnerV2 route with the one-line fix
- verified the modified Python file parses successfully and the commit contains only this configuration change