### PR TITLE
Fix merchant queue waits; verify-driven salvage/identify

### DIFF
--- a/Py4GWCoreLib/Inventory.py
+++ b/Py4GWCoreLib/Inventory.py
@@ -43,12 +43,17 @@ class Inventory:
     SALVAGE_CHOICE_DIALOG_LABEL = "Salvage Window"
     SALVAGE_CHOICE_OPTION_CONTAINER_LABEL = "Salvage Window.Options"
     SALVAGE_CHOICE_CONFIRM_LABEL = "Salvage Window.Salvage Button"
-    SALVAGE_CHOICE_MATERIAL_CONFIRM_YES_LABEL = "Salvage Materials Dialog.Yes Button"
     SALVAGE_CHOICE_FALLBACK_DIALOG_HASH = 684387150
     SALVAGE_CHOICE_FALLBACK_OPTION_CONTAINER_OFFSET = 5
     SALVAGE_CHOICE_FALLBACK_CONFIRM_OFFSET = 2
-    SALVAGE_CHOICE_FALLBACK_MATERIAL_CONFIRM_ROOT_OFFSET = 0
-    SALVAGE_CHOICE_FALLBACK_MATERIAL_CONFIRM_YES_OFFSET = 6
+    MATERIAL_CONFIRM_SCREEN_TEMPLATE = 0
+    MATERIAL_CONFIRM_SCREEN_OFFSET = 6
+    MATERIAL_CONFIRM_DIALOG_TEMPLATE = 2
+    MATERIAL_CONFIRM_ICON_TEMPLATE = 6
+    MATERIAL_CONFIRM_ICON_OFFSET = 0
+    MATERIAL_CONFIRM_BUTTON_TEMPLATE = 7
+    MATERIAL_CONFIRM_YES_OFFSET = 6
+    MATERIAL_CONFIRM_NO_OFFSET = 4
 
     @staticmethod
     def inventory_instance():
@@ -390,20 +395,14 @@ class Inventory:
     
     @staticmethod
     def AcceptSalvageMaterialsWindow():
-        """
-        Checks if the Salvage Materials Dialog frame exists and clicks it if it hasn't already been clicked.
-        Returns:
-            bool: True if click was performed, False otherwise.
-        """
+        """Accept the salvage materials confirm dialog, but only once the full dialog
+        signature has been verified."""
         from .UIManager import UIManager
 
-        parent_hash = 140452905
-        yes_button_offsets = [6,113,6]
-        
-        salvage_material_window = UIManager.GetChildFrameID(parent_hash, yes_button_offsets)
-        UIManager.FrameClick(salvage_material_window)
-     
-        #return Inventory.inventory_instance().AcceptSalvageWindow()
+        yes_frame_id = Inventory._get_salvage_choice_material_confirm_yes_frame_id()
+        if yes_frame_id == 0:
+            return
+        UIManager.FrameClick(yes_frame_id)
 
     @staticmethod
     def _get_frame_id_by_alias(frame_label: str) -> int:
@@ -444,22 +443,69 @@ class Inventory:
 
     @staticmethod
     def _get_salvage_choice_material_confirm_yes_frame_id() -> int:
-        from .UIManager import UIManager
+        return Inventory.find_material_confirm_yes_frame()
 
-        yes_frame_id = Inventory._get_frame_id_by_alias(Inventory.SALVAGE_CHOICE_MATERIAL_CONFIRM_YES_LABEL)
-        if yes_frame_id != 0:
+    @staticmethod
+    def find_material_confirm_yes_frame() -> int:
+        """Identify the confirm dialog's Yes button purely by template_type + child
+        offset. This dialog carries no frame_hash and no label, and its own child
+        offset is a creation-order slot (98/100/109/110/111/113 all seen), so the
+        surrounding tree pattern is the only stable identity available:
+
+            template 0, offset 6      screen frame
+            └── template 2            dialog (its offset varies -- ignored)
+                ├── template 6, offset 0   icon
+                ├── template 7, offset 4   No button
+                └── template 7, offset 6   Yes button
+        """
+        from .UIManager import UIManager
+        import PyUIManager
+
+        frames: dict[int, tuple[int, int, int]] = {}
+        children_by_parent: dict[int, dict[int, int]] = {}
+        for frame_id in UIManager.GetFrameArray():
+            try:
+                frame = PyUIManager.UIFrame(frame_id)
+                parent_id = int(frame.parent_id or 0)
+                child_offset = int(frame.child_offset_id or 0)
+                template_type = int(frame.template_type or 0)
+            except Exception:
+                continue
+            frames[frame_id] = (parent_id, child_offset, template_type)
+            children_by_parent.setdefault(parent_id, {})[child_offset] = frame_id
+
+        def matches(frame_id: int, offset: int, template_type: int) -> bool:
+            record = frames.get(frame_id)
+            return record is not None and record[1] == offset and record[2] == template_type
+
+        for dialog_frame_id, (screen_frame_id, _, dialog_template) in frames.items():
+            if dialog_template != Inventory.MATERIAL_CONFIRM_DIALOG_TEMPLATE:
+                continue
+            if not matches(
+                screen_frame_id,
+                Inventory.MATERIAL_CONFIRM_SCREEN_OFFSET,
+                Inventory.MATERIAL_CONFIRM_SCREEN_TEMPLATE,
+            ):
+                continue
+
+            dialog_children = children_by_parent.get(dialog_frame_id, {})
+            icon_frame_id = dialog_children.get(Inventory.MATERIAL_CONFIRM_ICON_OFFSET, 0)
+            no_frame_id = dialog_children.get(Inventory.MATERIAL_CONFIRM_NO_OFFSET, 0)
+            yes_frame_id = dialog_children.get(Inventory.MATERIAL_CONFIRM_YES_OFFSET, 0)
+
+            if not matches(icon_frame_id, Inventory.MATERIAL_CONFIRM_ICON_OFFSET, Inventory.MATERIAL_CONFIRM_ICON_TEMPLATE):
+                continue
+            if not matches(no_frame_id, Inventory.MATERIAL_CONFIRM_NO_OFFSET, Inventory.MATERIAL_CONFIRM_BUTTON_TEMPLATE):
+                continue
+            if not matches(yes_frame_id, Inventory.MATERIAL_CONFIRM_YES_OFFSET, Inventory.MATERIAL_CONFIRM_BUTTON_TEMPLATE):
+                continue
+
+            if not (UIManager.FrameExists(dialog_frame_id) and UIManager.FrameExists(yes_frame_id)):
+                continue
+
             return yes_frame_id
 
-        fallback_frame_id = UIManager.GetChildFrameID(
-            Inventory.SALVAGE_CHOICE_FALLBACK_DIALOG_HASH,
-            [
-                Inventory.SALVAGE_CHOICE_FALLBACK_MATERIAL_CONFIRM_ROOT_OFFSET,
-                Inventory.SALVAGE_CHOICE_FALLBACK_MATERIAL_CONFIRM_YES_OFFSET,
-            ],
-        )
-        if fallback_frame_id == 0 or not UIManager.FrameExists(fallback_frame_id):
-            return 0
-        return fallback_frame_id
+        return 0
 
     @staticmethod
     def IsSalvageChoiceMaterialConfirmVisible() -> bool:

--- a/Py4GWCoreLib/routines_src/Sequential.py
+++ b/Py4GWCoreLib/routines_src/Sequential.py
@@ -402,7 +402,8 @@ class Sequential:
                 cost = quantity * value
                 GLOBAL_CACHE.Trading.Merchant.SellItem(item_id, cost)
                     
-            while not ActionQueueManager().IsEmpty("MERCHANT"):
+            # Merchant buy/sell land on the shared "ACTION" queue, not "MERCHANT".
+            while not ActionQueueManager().IsEmpty("ACTION"):
                 sleep(0.35)
             
             if log:
@@ -429,8 +430,8 @@ class Sequential:
                 item_id = merchant_item_list[0]
                 value = GLOBAL_CACHE.Item.Properties.GetValue(item_id) * 2 # value reported is sell value not buy value
                 GLOBAL_CACHE.Trading.Merchant.BuyItem(item_id, value)
-                
-            while not ActionQueueManager().IsEmpty("MERCHANT"):
+
+            while not ActionQueueManager().IsEmpty("ACTION"):
                 sleep(0.35)
                 
             if log:
@@ -457,8 +458,8 @@ class Sequential:
                 item_id = merchant_item_list[0]
                 value = GLOBAL_CACHE.Item.Properties.GetValue(item_id) * 2
                 GLOBAL_CACHE.Trading.Merchant.BuyItem(item_id, value)
-                
-            while not ActionQueueManager().IsEmpty("MERCHANT"):
+
+            while not ActionQueueManager().IsEmpty("ACTION"):
                 sleep(0.35)
             
             if log:

--- a/Py4GWCoreLib/routines_src/behaviourtrees_src/items.py
+++ b/Py4GWCoreLib/routines_src/behaviourtrees_src/items.py
@@ -1893,3 +1893,138 @@ class BTItems:
                 ],
             )
         )
+
+    @staticmethod
+    def IdentifyInventoryItems(
+        rarities: list[str] | None = None,
+        per_item_delay_ms: int = 50,
+        log: bool = False,
+    ) -> BehaviorTree:
+        """
+        Build a tree that identifies every unidentified inventory item matching the rarity filter.
+
+        Meta:
+          Expose: true
+          Audience: beginner
+          Display: Identify Inventory Items
+          Purpose: Identify every unidentified item currently in inventory bags.
+          UserDescription: Use this when you want a BT step that runs a full identify pass with no manual item list.
+          Notes: Auto-collects on first tick from Backpack + Belt Pouch + Bag 1 + Bag 2. Defaults to Blue/Purple/Gold when rarities is omitted, plus any item carrying a hidden upgrade. per_item_delay_ms throttles the packet rate to avoid anti-abuse disconnects.
+        """
+        active_rarities = set(rarities if rarities is not None else ["Blue", "Purple", "Gold"])
+        state = {"gen": None}
+
+        def collect_unidentified_ids() -> list[int]:
+            from ...Item import Item
+            picked: list[int] = []
+            seen: set[int] = set()
+            for item_id in GLOBAL_CACHE.Inventory.GetAllInventoryItemIds():
+                if item_id in seen or item_id == 0:
+                    continue
+                seen.add(item_id)
+                try:
+                    inst = Item.item_instance(item_id)
+                    if inst is None or not inst.is_inventory_item:
+                        continue
+                    if inst.is_identified:
+                        continue
+                    carries_hidden_upgrade = not inst.is_prefix_upgradable or not inst.is_suffix_upgradable
+                    if inst.rarity.name not in active_rarities and not carries_hidden_upgrade:
+                        continue
+                except Exception:
+                    continue
+                picked.append(item_id)
+            return picked
+
+        def tick(node: BehaviorTree.Node) -> BehaviorTree.NodeState:
+            import PySystem
+            from ..yield_src.items import Items as YieldItems
+            if state["gen"] is None:
+                item_ids = collect_unidentified_ids()
+                PySystem.Console.Log("IdentifyInventoryItems", f"Auto-collected {len(item_ids)} unidentified items (rarities={sorted(active_rarities)}).", PySystem.Console.MessageType.Info)
+                if not item_ids:
+                    return BehaviorTree.NodeState.SUCCESS
+                state["gen"] = YieldItems.IdentifyItemsAndVerify(item_ids, log=log, per_item_delay_ms=per_item_delay_ms)
+                PySystem.Console.Log("IdentifyInventoryItems", "Generator created; starting first tick.", PySystem.Console.MessageType.Info)
+            try:
+                next(state["gen"])
+                return BehaviorTree.NodeState.RUNNING
+            except StopIteration:
+                state["gen"] = None
+                PySystem.Console.Log("IdentifyInventoryItems", "Generator exhausted; returning SUCCESS.", PySystem.Console.MessageType.Info)
+                return BehaviorTree.NodeState.SUCCESS
+
+        return BehaviorTree(
+            BehaviorTree.ActionNode(name="IdentifyInventoryItems", action_fn=tick, aftercast_ms=0)
+        )
+
+    @staticmethod
+    def SalvageInventoryItems(
+        rarities: list[str] | None = None,
+        per_item_delay_ms: int = 100,
+        log: bool = False,
+    ) -> BehaviorTree:
+        """
+        Build a tree that salvages every salvageable inventory item matching the rarity filter.
+
+        Meta:
+          Expose: true
+          Audience: beginner
+          Display: Salvage Inventory Items
+          Purpose: Salvage every salvageable item currently in inventory bags.
+          UserDescription: Use this when you want a BT step that runs a full salvage pass with no manual item list.
+          Notes: Auto-collects on first tick and skips items that are not identified (except whites). Handles the Purple/Gold materials confirmation dialog automatically. per_item_delay_ms throttles the packet rate to avoid anti-abuse disconnects.
+        """
+        active_rarities = set(rarities if rarities is not None else ["White", "Blue", "Purple", "Gold"])
+        state = {"gen": None}
+
+        def collect_salvageable_ids() -> list[int]:
+            from ...Item import Item
+            picked: list[int] = []
+            seen: set[int] = set()
+            for item_id in GLOBAL_CACHE.Inventory.GetAllInventoryItemIds():
+                if item_id in seen or item_id == 0:
+                    continue
+                seen.add(item_id)
+                try:
+                    inst = Item.item_instance(item_id)
+                    if inst is None or not inst.is_inventory_item:
+                        continue
+                    if inst.is_salvage_kit or inst.is_id_kit:
+                        continue
+                    if not inst.is_salvageable:
+                        continue
+                    rarity_name = inst.rarity.name
+                    if rarity_name not in active_rarities:
+                        continue
+                    carries_hidden_upgrade = not inst.is_prefix_upgradable or not inst.is_suffix_upgradable
+                    # An unidentified item can under-report its rarity as White, so rarity alone
+                    # is not enough to keep unidentified blues out of the salvage list.
+                    if not inst.is_identified and (rarity_name != "White" or carries_hidden_upgrade):
+                        continue
+                except Exception:
+                    continue
+                picked.append(item_id)
+            return picked
+
+        def tick(node: BehaviorTree.Node) -> BehaviorTree.NodeState:
+            import PySystem
+            from ..yield_src.items import Items as YieldItems
+            if state["gen"] is None:
+                item_ids = collect_salvageable_ids()
+                PySystem.Console.Log("SalvageInventoryItems", f"Auto-collected {len(item_ids)} salvageable items (rarities={sorted(active_rarities)}).", PySystem.Console.MessageType.Info)
+                if not item_ids:
+                    return BehaviorTree.NodeState.SUCCESS
+                state["gen"] = YieldItems.SalvageItemsAndVerify(item_ids, log=log, per_item_delay_ms=per_item_delay_ms)
+                PySystem.Console.Log("SalvageInventoryItems", "Generator created; starting first tick.", PySystem.Console.MessageType.Info)
+            try:
+                next(state["gen"])
+                return BehaviorTree.NodeState.RUNNING
+            except StopIteration:
+                state["gen"] = None
+                PySystem.Console.Log("SalvageInventoryItems", "Generator exhausted; returning SUCCESS.", PySystem.Console.MessageType.Info)
+                return BehaviorTree.NodeState.SUCCESS
+
+        return BehaviorTree(
+            BehaviorTree.ActionNode(name="SalvageInventoryItems", action_fn=tick, aftercast_ms=0)
+        )

--- a/Py4GWCoreLib/routines_src/yield_src/items.py
+++ b/Py4GWCoreLib/routines_src/yield_src/items.py
@@ -14,6 +14,44 @@ from .movement import Movement
 from .player import Player as YieldPlayer
 
 
+def item_still_present(item_id: int) -> bool:
+    from ...Item import Item
+    try:
+        item = Item.item_instance(item_id)
+        if item is None:
+            return False
+        return bool(item.is_inventory_item)
+    except Exception:
+        return False
+
+
+def item_quantity(item_id: int) -> int:
+    from ...Item import Item
+    try:
+        item = Item.item_instance(item_id)
+        if item is None or not item.is_inventory_item:
+            return 0
+        return int(item.quantity)
+    except Exception:
+        return 0
+
+
+def item_is_identified(item_id: int) -> bool:
+    from ...Item import Item
+    try:
+        item = Item.item_instance(item_id)
+        if item is None or not item.is_inventory_item:
+            return True
+        return bool(item.is_identified)
+    except Exception:
+        return True
+
+
+def is_materials_confirm_window_open() -> bool:
+    from ...Inventory import Inventory
+    return Inventory.IsSalvageChoiceMaterialConfirmVisible()
+
+
 class Items:
     @staticmethod
     def _finish_active_pick_up_loot_message() -> bool:
@@ -37,16 +75,11 @@ class Items:
 
     @staticmethod
     def _wait_for_salvage_materials_window(timeout_ms: int = 1200, poll_ms: int = 50, initial_wait_ms: int = 150):
-        from ...UIManager import UIManager
         yield from wait(max(0, initial_wait_ms))
-
-        parent_hash = 140452905
-        yes_button_offsets = [6, 110, 6]
         waited_ms = 0
 
         while waited_ms < max(0, timeout_ms):
-            salvage_materials_frame = UIManager.GetChildFrameID(parent_hash, yes_button_offsets)
-            if salvage_materials_frame and UIManager.FrameExists(salvage_materials_frame):
+            if is_materials_confirm_window_open():
                 yield from wait(max(0, poll_ms))
                 return True
 
@@ -144,6 +177,183 @@ class Items:
 
         if log and len(item_array) > 0:
             ConsoleLog("IdentifyItems", f"Identified {len(item_array)} items.", Console.MessageType.Info)
+
+    @staticmethod
+    def clear_pending_salvage_confirm(item_id: int = 0, close_timeout_ms: int = 1500, poll_ms: int = 50):
+        """Accept any open rare-salvage confirm dialog. Firing a new salvage while
+        one is still open corrupts the client's salvage session and crashes it."""
+        from ...Inventory import Inventory
+
+        if not is_materials_confirm_window_open():
+            return True
+
+        status = yield from Inventory.HandleSalvageChoiceMaterialConfirmDialog(
+            auto_confirm=True,
+            queue_name="SALVAGE",
+            log_module="SalvageItemsAndVerify",
+            poll_ms=poll_ms,
+            close_timeout_ms=close_timeout_ms,
+            item_id=item_id,
+        )
+        return status in ("handled", "not_visible")
+
+    @staticmethod
+    def SalvageItemsAndVerify(
+        item_array: list[int],
+        log: bool = False,
+        per_item_delay_ms: int = 100,
+        per_item_timeout_ms: int = 3000,
+        poll_ms: int = 50,
+    ):
+        """Salvage each item once, then verify completion by polling item
+        state (quantity drop / item removal) plus the materials-confirm
+        window. Advances the moment the game confirms the salvage landed
+        instead of sleeping a fixed delay. Handles Purple/Gold confirm
+        dialogs automatically."""
+        import time
+        from ...Py4GWcorelib import ActionQueueManager, ConsoleLog, Console
+        from ...Inventory import Inventory
+
+        if len(item_array) == 0:
+            ActionQueueManager().ResetQueue("SALVAGE")
+            return
+
+        salvaged_count = 0
+        for item_id in item_array:
+            dialog_cleared = yield from Items.clear_pending_salvage_confirm(item_id, poll_ms=poll_ms)
+            if not dialog_cleared:
+                ConsoleLog(
+                    "SalvageItemsAndVerify",
+                    "Salvage confirm dialog stuck open; aborting rather than salvaging into it.",
+                    Console.MessageType.Error,
+                )
+                break
+
+            if not item_still_present(item_id):
+                ConsoleLog("SalvageItemsAndVerify", f"Skip item_id={item_id}: not present.", Console.MessageType.Warning)
+                continue
+
+            _, rarity = GLOBAL_CACHE.Item.Rarity.GetRarity(item_id)
+            initial_qty = item_quantity(item_id)
+
+            kit_id = GLOBAL_CACHE.Inventory.GetFirstSalvageKit()
+            if kit_id == 0:
+                ConsoleLog("SalvageItemsAndVerify", "Out of salvage kits.", Console.MessageType.Warning)
+                break
+
+            ConsoleLog("SalvageItemsAndVerify", f"Firing salvage item_id={item_id} rarity={rarity} qty={initial_qty} kit={kit_id}.", Console.MessageType.Info)
+            ActionQueueManager().AddAction("SALVAGE", Inventory.SalvageItem, item_id, kit_id)
+            queue_drained = yield from Items._wait_for_empty_queue("SALVAGE", timeout_ms=5000)
+            if not queue_drained:
+                ConsoleLog("SalvageItemsAndVerify", f"Salvage queue never drained (item_id={item_id}).", Console.MessageType.Warning)
+                continue
+
+            fired_at = time.monotonic()
+            confirm_handled = False
+            salvage_stalled = False
+
+            while True:
+                yield from wait(max(1, poll_ms))
+                now = time.monotonic()
+
+                if not item_still_present(item_id):
+                    salvaged_count += 1
+                    break
+                if item_quantity(item_id) < initial_qty:
+                    salvaged_count += 1
+                    break
+
+                if not confirm_handled and is_materials_confirm_window_open():
+                    status = yield from Inventory.HandleSalvageChoiceMaterialConfirmDialog(
+                        auto_confirm=True,
+                        queue_name="SALVAGE",
+                        log_module="SalvageItemsAndVerify",
+                        poll_ms=poll_ms,
+                        item_id=item_id,
+                    )
+                    confirm_handled = status == "handled"
+                    fired_at = time.monotonic()
+                    continue
+
+                if (now - fired_at) * 1000 >= per_item_timeout_ms:
+                    ConsoleLog(
+                        "SalvageItemsAndVerify",
+                        f"Timeout item_id={item_id} rarity={rarity} "
+                        f"initial_qty={initial_qty} current_qty={item_quantity(item_id)} "
+                        f"confirm_handled={confirm_handled}.",
+                        Console.MessageType.Warning,
+                    )
+                    salvage_stalled = True
+                    break
+
+            if salvage_stalled:
+                ConsoleLog(
+                    "SalvageItemsAndVerify",
+                    f"Aborting: item_id={item_id} never left inventory, so a dialog is likely still open. "
+                    "Firing the next salvage now would crash the client.",
+                    Console.MessageType.Error,
+                )
+                break
+
+            yield from wait(max(0, per_item_delay_ms))
+
+        if log and salvaged_count > 0:
+            ConsoleLog("SalvageItemsAndVerify", f"Salvaged {salvaged_count} items.", Console.MessageType.Info)
+
+    @staticmethod
+    def IdentifyItemsAndVerify(
+        item_array: list[int],
+        log: bool = False,
+        per_item_delay_ms: int = 50,
+        per_item_timeout_ms: int = 2000,
+        poll_ms: int = 50,
+    ):
+        """Identify each item once, then verify by polling item.is_identified
+        until true (or timeout). Runs at the speed the game actually resolves
+        each identify rather than a fixed pause."""
+        import time
+        from ...Py4GWcorelib import ActionQueueManager, ConsoleLog, Console
+        from ...Inventory import Inventory
+
+        if len(item_array) == 0:
+            ActionQueueManager().ResetQueue("IDENTIFY")
+            return
+
+        identified_count = 0
+        for item_id in item_array:
+            if item_is_identified(item_id):
+                continue
+
+            kit_id = GLOBAL_CACHE.Inventory.GetFirstIDKit()
+            if kit_id == 0:
+                ConsoleLog("IdentifyItemsAndVerify", "Out of ID kits.", Console.MessageType.Warning)
+                break
+
+            ActionQueueManager().AddAction("IDENTIFY", Inventory.IdentifyItem, item_id, kit_id)
+            queue_drained = yield from Items._wait_for_empty_queue("IDENTIFY", timeout_ms=5000)
+            if not queue_drained:
+                ConsoleLog("IdentifyItemsAndVerify", f"Identify queue never drained (item_id={item_id}).", Console.MessageType.Warning)
+                continue
+
+            fired_at = time.monotonic()
+
+            while True:
+                yield from wait(max(1, poll_ms))
+                if item_is_identified(item_id):
+                    identified_count += 1
+                    break
+                if (time.monotonic() - fired_at) * 1000 >= per_item_timeout_ms:
+                    ConsoleLog(
+                        "IdentifyItemsAndVerify",
+                        f"Timeout item_id={item_id} after {per_item_timeout_ms}ms.",
+                        Console.MessageType.Warning,
+                    )
+                    break
+
+            yield from wait(max(0, per_item_delay_ms))
+
+        if log and identified_count > 0:
+            ConsoleLog("IdentifyItemsAndVerify", f"Identified {identified_count} items.", Console.MessageType.Info)
 
     @staticmethod
     def DepositItems(item_array: list[int], log=False):

--- a/Py4GWCoreLib/routines_src/yield_src/merchant.py
+++ b/Py4GWCoreLib/routines_src/yield_src/merchant.py
@@ -463,7 +463,6 @@ class Merchant:
         from ...Py4GWcorelib import ActionQueueManager, ConsoleLog, Console
 
         if len(item_array) == 0:
-            ActionQueueManager().ResetQueue("MERCHANT")
             return
 
         for item_id in item_array:
@@ -472,65 +471,89 @@ class Merchant:
             cost = quantity * value
             GLOBAL_CACHE.Trading.Merchant.SellItem(item_id, cost)
 
-        while not ActionQueueManager().IsEmpty("MERCHANT"):
+        # Merchant buy/sell land on the shared "ACTION" queue, not "MERCHANT".
+        while not ActionQueueManager().IsEmpty("ACTION"):
             yield from wait(50)
 
         if log:
             ConsoleLog("SellItems", f"Sold {len(item_array)} items.", Console.MessageType.Info)
 
     @staticmethod
-    def BuyIDKits(kits_to_buy: int, log=False):
-        from ...Py4GWcorelib import ActionQueueManager, ConsoleLog, Console
+    def BuyModelFromMerchant(
+        model_id: int,
+        amount: int,
+        log_module: str,
+        log: bool = False,
+        per_item_timeout_ms: int = 3000,
+        poll_ms: int = 50,
+    ):
+        """Buy `amount` copies of a merchant-offered model, verifying each purchase
+        landed in inventory before requesting the next one."""
+        from ...Py4GWcorelib import ConsoleLog, Console
         from ...ItemArray import ItemArray
 
-        if kits_to_buy <= 0:
-            ActionQueueManager().ResetQueue("MERCHANT")
-            return
+        if amount <= 0:
+            return 0
 
-        merchant_item_list = GLOBAL_CACHE.Trading.Merchant.GetOfferedItems()
-        merchant_item_list = ItemArray.Filter.ByCondition(merchant_item_list, lambda item_id: GLOBAL_CACHE.Item.GetModelID(item_id) == 5899)
+        offered_items = GLOBAL_CACHE.Trading.Merchant.GetOfferedItems()
+        offered_items = ItemArray.Filter.ByCondition(offered_items, lambda item_id: GLOBAL_CACHE.Item.GetModelID(item_id) == model_id)
+        if len(offered_items) == 0:
+            ConsoleLog(log_module, f"Merchant is not offering model {model_id}.", Console.MessageType.Warning)
+            return 0
 
-        if len(merchant_item_list) == 0:
-            ActionQueueManager().ResetQueue("MERCHANT")
-            return
+        offered_item_id = offered_items[0]
+        value = GLOBAL_CACHE.Item.Properties.GetValue(offered_item_id) * 2
+        bought = 0
 
-        for i in range(kits_to_buy):
-            item_id = merchant_item_list[0]
-            value = GLOBAL_CACHE.Item.Properties.GetValue(item_id) * 2
-            GLOBAL_CACHE.Trading.Merchant.BuyItem(item_id, value)
+        for _ in range(amount):
+            count_before = Merchant._count_model_in_inventory(model_id)
+            GLOBAL_CACHE.Trading.Merchant.BuyItem(offered_item_id, value)
 
-        while not ActionQueueManager().IsEmpty("MERCHANT"):
-            yield from wait(50)
+            elapsed_ms = 0
+            while elapsed_ms < per_item_timeout_ms:
+                yield from wait(poll_ms)
+                elapsed_ms += poll_ms
+                if Merchant._count_model_in_inventory(model_id) > count_before:
+                    break
+            else:
+                ConsoleLog(
+                    log_module,
+                    f"Purchase of model {model_id} never arrived (bought {bought}/{amount}); stopping.",
+                    Console.MessageType.Warning,
+                )
+                return bought
+
+            bought += 1
 
         if log:
-            ConsoleLog("BuyIDKits", f"Bought {kits_to_buy} ID Kits.", Console.MessageType.Info)
+            ConsoleLog(log_module, f"Bought {bought} of model {model_id}.", Console.MessageType.Info)
+        return bought
+
+    @staticmethod
+    def BuyIDKits(kits_to_buy: int, log=False):
+        bought = yield from Merchant.BuyModelFromMerchant(
+            ModelID.Superior_Identification_Kit.value,
+            kits_to_buy,
+            "BuyIDKits",
+            log=log,
+        )
+        if bought < kits_to_buy:
+            bought += (yield from Merchant.BuyModelFromMerchant(
+                ModelID.Identification_Kit.value,
+                kits_to_buy - bought,
+                "BuyIDKits",
+                log=log,
+            ))
+        return bought
 
     @staticmethod
     def BuySalvageKits(kits_to_buy: int, log=False):
-        from ...ItemArray import ItemArray
-        from ...Py4GWcorelib import ActionQueueManager, ConsoleLog, Console
-
-        if kits_to_buy <= 0:
-            ActionQueueManager().ResetQueue("MERCHANT")
-            return
-
-        merchant_item_list = GLOBAL_CACHE.Trading.Merchant.GetOfferedItems()
-        merchant_item_list = ItemArray.Filter.ByCondition(merchant_item_list, lambda item_id: GLOBAL_CACHE.Item.GetModelID(item_id) == 2992)
-
-        if len(merchant_item_list) == 0:
-            ActionQueueManager().ResetQueue("MERCHANT")
-            return
-
-        for i in range(kits_to_buy):
-            item_id = merchant_item_list[0]
-            value = GLOBAL_CACHE.Item.Properties.GetValue(item_id) * 2
-            GLOBAL_CACHE.Trading.Merchant.BuyItem(item_id, value)
-
-        while not ActionQueueManager().IsEmpty("MERCHANT"):
-            yield from wait(50)
-
-        if log:
-            ConsoleLog("BuySalvageKits", f"Bought {kits_to_buy} Salvage Kits.", Console.MessageType.Info)
+        return (yield from Merchant.BuyModelFromMerchant(
+            ModelID.Salvage_Kit.value,
+            kits_to_buy,
+            "BuySalvageKits",
+            log=log,
+        ))
 
     @staticmethod
     def BuyMaterial(


### PR DESCRIPTION
TLDR: Added a bunch of fixes to Salvage/Identify - made BT equivalent of verifying an item is identified/salvaged, so we can do this action faster, and cause it to not crash during Salvage/Identify/Buying stuff.


Five files, no new modules. Fixes the merchant restock path (which never actually
waited on anything), replaces an unstable frame lookup, and adds verify-driven
salvage/identify routines plus the two BT nodes that wrap them.

Extracted from a larger local branch and rebased clean onto `main`. Everything here
has been running in a live farming loop.

---

## 1. `IsEmpty("MERCHANT")` never waits — the queue is always empty

`GLOBAL_CACHE.Trading.Merchant.BuyItem` / `SellItem` enqueue onto **`"ACTION"`**:

```python
# Py4GWCoreLib/GlobalCache/MerchantCache.py:48
def BuyItem(self, item_id, cost):
    self._parent._action_queue_manager.AddAction("ACTION", ..., item_id, cost)
```

Nothing in the repo ever calls `AddAction("MERCHANT", ...)`. So every

```python
while not ActionQueueManager().IsEmpty("MERCHANT"):
    yield from wait(50)
```

falls through on the first check, and the routine returns before a single packet is
sent. `ResetQueue("MERCHANT")` is a no-op for the same reason.

Fixed in `yield_src/merchant.py` and the three `Sequential.py` merchant routines by
waiting on `"ACTION"`.

> Same bug also exists at `Widgets/Guild Wars/Items & Loot/MerchantRules.py:18656`.
> Left alone here to keep this PR to the core lib — happy to follow up.

## 2. Merchant purchases are now confirmed one at a time

`BuyIDKits` / `BuySalvageKits` fired N buy requests in a tight loop, then waited once
(and, per the above, not even that). New `BuyModelFromMerchant` checks inventory for
the model after each request and only then requests the next; if a purchase never
lands it stops and warns with a `bought/requested` count instead of spinning.

`BuyIDKits` also falls back to `Identification_Kit` when the merchant does not stock
`Superior_Identification_Kit`. Both keep their existing signatures and remain
generators, so callers are unaffected.

## 3. Materials-confirm dialog: hash + fixed offset → template pattern

The rare-salvage "you will destroy the mods" Yes button was found by frame hash plus
a hardcoded child-offset path:

```python
parent_hash = 140452905
yes_button_offsets = [6, 110, 6]   # and [6, 113, 6] elsewhere in the same file
```

Neither anchor holds. The dialog carries no frame hash and no label, and its child
offset is a **creation-order slot** — 98, 100, 109, 110, 111 and 113 have all been
observed across sessions. The two call sites had already drifted to different
offsets, which is the bug showing through.

`Inventory.find_material_confirm_yes_frame()` matches the surrounding tree shape
instead, which is the only stable signature the frame exposes:

```
template 0, offset 6            screen frame
└── template 2                  dialog (own offset varies — ignored)
    ├── template 6, offset 0    icon
    ├── template 7, offset 4    No button
    └── template 7, offset 6    Yes button
```

The old `SALVAGE_CHOICE_FALLBACK_*` constants for the *choice* window are untouched;
only the material-confirm ones were replaced.

## 4. Verify-driven salvage / identify

`SalvageItemsAndVerify` and `IdentifyItemsAndVerify` latch on observed client state —
quantity drop, item removal, `is_identified` — instead of sleeping a fixed delay per
item. They advance the moment the game confirms, and log a diagnostic on timeout
rather than silently continuing.

Salvage additionally clears any open materials-confirm dialog **before** firing the
next item, and aborts the batch if it cannot. This is the important one: firing a
salvage while that dialog is still open corrupts the client's salvage session and
crashes it. The old fixed-delay loop hit this regularly on gold-heavy runs.

Existing `SalvageItems` / `IdentifyItems` are left in place and unchanged.

## 5. BT nodes

`BTItems.IdentifyInventoryItems` and `BTItems.SalvageInventoryItems` wrap the two
passes as behaviour tree steps that auto-collect from Backpack + Belt Pouch + Bag 1 +
Bag 2 on first tick, so a tree needs no hand-maintained item list. Both carry `Meta:`
blocks matching the convention already in that file.

Salvage collection deliberately skips unidentified non-whites: an unidentified item
can under-report its rarity as White, so rarity alone is not enough to keep
unidentified blues out of the list.

---

## Verification

- Byte-compiles under `.venv/Scripts/python.exe` (3.13.0, 32-bit).
- `pyflakes` diffed against the `main` baseline for all five files — **no new findings**.
- Deliberately **not** run through `black`: these files are not black-clean on `main`
  either, so formatting them would bury a ~500-line change in thousands of lines of
  unrelated reflow. Formatting left exactly as-is.
- Exercised live in a repeating COF farm loop (identify + salvage + merchant restock)
  across gold/purple drops, which is what surfaced both the dialog crash and the
  no-op merchant wait.

No new files, no persistence changes, no new dependencies.
