### PR TITLE
Script manager: metadata discovery, dependency-aware loader, widget

### DIFF
--- a/Py4GWCoreLib/py4gwcorelib_src/script_manager/__init__.py
+++ b/Py4GWCoreLib/py4gwcorelib_src/script_manager/__init__.py
@@ -1,0 +1,27 @@
+"""Script manager — flat, metadata-driven discovery for ``Scripts/``."""
+
+from .discovery import RESOURCES
+from .discovery import SUBSUMES
+from .discovery import ScriptMeta
+from .discovery import ScriptRegistry
+from .discovery import build_meta
+from .discovery import find_block
+from .discovery import parse_metadata
+from .loader import PROTECTED_ROOTS
+from .loader import RELOAD_ROOTS
+from .loader import ScriptLoader
+from .loader import shared_with_widgets
+
+__all__ = [
+    "PROTECTED_ROOTS",
+    "RELOAD_ROOTS",
+    "RESOURCES",
+    "SUBSUMES",
+    "ScriptLoader",
+    "ScriptMeta",
+    "ScriptRegistry",
+    "build_meta",
+    "find_block",
+    "parse_metadata",
+    "shared_with_widgets",
+]

--- a/Py4GWCoreLib/py4gwcorelib_src/script_manager/discovery.py
+++ b/Py4GWCoreLib/py4gwcorelib_src/script_manager/discovery.py
@@ -1,0 +1,241 @@
+"""Script discovery — reads ``__script__`` metadata without importing the module.
+
+No ImGui and no Py4GW imports: this module must stay importable and unit-testable from a
+plain interpreter, same contract as ``launch_bar.model``.
+
+Scripts live flat in ``Scripts/`` and declare a literal ``__script__`` dict near the top of
+the file. Discovery reads only the first ``HEADER_WINDOW`` bytes of each file, so a rescan
+costs ~18ms for 150 scripts instead of ~3s for a full ``ast.parse`` of every module.
+"""
+
+import ast
+import os
+from dataclasses import dataclass
+
+HEADER_WINDOW = 8192
+
+RESOURCES = ("character", "inventory", "skills", "dialog", "ui", "sharedmem")
+
+# A script driving the character also drives NPC interaction, so it must exclude
+# dialog senders even though it never declares `dialog` itself.
+SUBSUMES = {"character": ("dialog",)}
+
+
+@dataclass
+class ScriptMeta:
+    id: str
+    name: str
+    path: str
+    function: str = ""
+    tags: tuple = ()
+    claims: tuple = ()
+    mtime: float = 0.0
+    error: str = ""
+
+    def resources(self) -> set:
+        out = set(self.claims)
+        for claim in self.claims:
+            out.update(SUBSUMES.get(claim, ()))
+        return out
+
+    def conflicts_with(self, other: "ScriptMeta") -> bool:
+        return bool(self.resources() & other.resources())
+
+
+def find_block(text: str) -> str:
+    """Return the ``{...}`` source of the ``__script__`` assignment, or "" if incomplete.
+
+    Brace-matched rather than searched for the next "}" so nested dicts and braces inside
+    string values do not truncate the block.
+    """
+    at = text.find("__script__")
+    if at < 0:
+        return ""
+    start = text.find("{", at)
+    if start < 0:
+        return ""
+    depth = 0
+    quote = ""
+    escaped = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if quote:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = ""
+            continue
+        if ch in "\"'":
+            quote = ch
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return ""
+
+
+def parse_metadata(path: str) -> dict:
+    """Read a script's ``__script__`` dict. Falls back to a full parse if the header
+    window truncated the block."""
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        head = handle.read(HEADER_WINDOW)
+    block = find_block(head)
+    if not block:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            block = find_block(handle.read())
+    if not block:
+        raise ValueError("no __script__ block")
+    value = ast.literal_eval(block)
+    if not isinstance(value, dict):
+        raise ValueError("__script__ is not a dict")
+    return value
+
+
+def build_meta(path: str, mtime: float) -> ScriptMeta:
+    script_id = os.path.splitext(os.path.basename(path))[0]
+    try:
+        raw = parse_metadata(path)
+    except Exception as exc:
+        return ScriptMeta(id=script_id, name=script_id, path=path, mtime=mtime, error=str(exc))
+    claims = tuple(str(c) for c in raw.get("claims", ()) if c)
+    unknown = [c for c in claims if c not in RESOURCES]
+    return ScriptMeta(
+        id=script_id,
+        name=str(raw.get("name") or script_id),
+        path=path,
+        function=str(raw.get("function") or ""),
+        tags=tuple(str(t) for t in raw.get("tags", ()) if t),
+        claims=claims,
+        mtime=mtime,
+        error="unknown claims: %s" % ", ".join(unknown) if unknown else "",
+    )
+
+
+class ScriptRegistry:
+    """Flat registry of ``Scripts/*.py``, refreshed on demand.
+
+    Nothing here runs on a timer. ``refresh()`` reconciles against disk and re-reads only
+    files whose mtime moved; ``changed_on_disk()`` answers the same question without
+    mutating anything, so a UI can badge "reload available" without reloading.
+    """
+
+    def __init__(self, path: str = "Scripts"):
+        self.path = path
+        self.scripts: dict = {}
+        self.pinned: set = set()
+        self.stale: set = set()
+        self.revision = 0
+
+    def scan_mtimes(self) -> dict:
+        try:
+            names = [f for f in os.listdir(self.path) if f.endswith(".py")]
+        except OSError:
+            return {}
+        out = {}
+        for name in names:
+            full = os.path.join(self.path, name)
+            try:
+                out[os.path.splitext(name)[0]] = (full, os.stat(full).st_mtime)
+            except OSError:
+                continue
+        return out
+
+    def changed_on_disk(self) -> bool:
+        """Whether a refresh would change anything. Stats every file; no side effects."""
+        seen = self.scan_mtimes()
+        if set(seen) != set(self.scripts):
+            return True
+        return any(self.scripts[k].mtime != m for k, (_, m) in seen.items())
+
+    def refresh(self) -> bool:
+        """Reconcile the registry against disk, re-reading only what changed."""
+        seen = self.scan_mtimes()
+        changed = False
+        for script_id in list(self.scripts):
+            if script_id not in seen:
+                del self.scripts[script_id]
+                self.stale.discard(script_id)
+                changed = True
+
+        for script_id, (full, mtime) in seen.items():
+            known = self.scripts.get(script_id)
+            if known is not None and known.mtime == mtime:
+                continue
+            if script_id in self.pinned:
+                # Running script: its imported module is authoritative until it stops.
+                if known is not None:
+                    self.stale.add(script_id)
+                    continue
+            self.scripts[script_id] = build_meta(full, mtime)
+            self.stale.discard(script_id)
+            changed = True
+
+        if changed:
+            self.revision += 1
+        return changed
+
+    def reload(self) -> bool:
+        self.scripts.clear()
+        self.stale.clear()
+        return self.refresh()
+
+    def pin(self, script_id: str) -> None:
+        self.pinned.add(script_id)
+
+    def unpin(self, script_id: str) -> None:
+        self.pinned.discard(script_id)
+        if script_id in self.stale:
+            self.stale.discard(script_id)
+            entry = self.scripts.get(script_id)
+            if entry is not None:
+                try:
+                    self.scripts[script_id] = build_meta(entry.path, os.stat(entry.path).st_mtime)
+                    self.revision += 1
+                except OSError:
+                    pass
+
+    def all(self) -> list:
+        return sorted(self.scripts.values(), key=lambda s: s.name.lower())
+
+    def get(self, script_id: str):
+        return self.scripts.get(script_id)
+
+    def functions(self) -> list:
+        return sorted({s.function for s in self.scripts.values() if s.function})
+
+    def tags(self) -> list:
+        return sorted({t for s in self.scripts.values() for t in s.tags})
+
+    def query(self, function: str = "", tag: str = "", claim: str = "", text: str = "") -> list:
+        needle = text.strip().lower()
+        out = []
+        for script in self.scripts.values():
+            if function and script.function != function:
+                continue
+            if tag and tag not in script.tags:
+                continue
+            if claim and claim not in script.claims:
+                continue
+            if needle and needle not in script.name.lower() and needle not in script.id.lower():
+                continue
+            out.append(script)
+        return sorted(out, key=lambda s: s.name.lower())
+
+    def blocked_by(self, script_id: str, running_ids) -> list:
+        """Which of ``running_ids`` would conflict with starting ``script_id``."""
+        candidate = self.scripts.get(script_id)
+        if candidate is None:
+            return []
+        out = []
+        for other_id in running_ids:
+            other = self.scripts.get(other_id)
+            if other is not None and other_id != script_id and candidate.conflicts_with(other):
+                out.append(other_id)
+        return sorted(out)
+
+    def errors(self) -> list:
+        return [s for s in self.scripts.values() if s.error]

--- a/Py4GWCoreLib/py4gwcorelib_src/script_manager/loader.py
+++ b/Py4GWCoreLib/py4gwcorelib_src/script_manager/loader.py
@@ -1,0 +1,141 @@
+"""Script loading with dependency reload.
+
+Re-importing a script is not enough to pick up edits to the code it imports: those
+modules stay cached in ``sys.modules``. This module drops the script's supporting
+modules before re-importing so a reload sees the edits.
+
+What may be dropped is deliberately narrow. ``Py4GWCoreLib`` is imported by 620 call
+sites across scripts and by every widget; dropping it mid-session would leave live
+widgets holding a half-replaced library. Only project code under ``RELOAD_ROOTS`` is
+eligible, and even then anything a widget also imports is protected -- see
+``shared_with_widgets``.
+"""
+
+import ast
+import importlib.util
+import os
+import sys
+
+RELOAD_ROOTS = ("Sources", "HeroAI", "Bots", "bot_factory")
+
+# Never dropped: shared with the widget host, or native modules that cannot be re-executed.
+PROTECTED_ROOTS = ("Py4GWCoreLib", "Py4GW_widget_manager", "Widgets", "Py4GW", "PySystem")
+
+MODULE_PREFIX = "py4gw_script_"
+
+
+def module_name_for(script_id: str) -> str:
+    safe = "".join(ch if ch.isalnum() else "_" for ch in script_id)
+    return MODULE_PREFIX + safe
+
+
+def imports_in(path: str) -> set:
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            tree = ast.parse(handle.read())
+    except (OSError, SyntaxError):
+        return set()
+    found = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            found.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            found.add(node.module)
+    return found
+
+
+def shared_with_widgets(widgets_path: str = "Widgets", reload_roots=RELOAD_ROOTS) -> set:
+    """Modules under ``reload_roots`` that a widget also imports.
+
+    Dropping one of these would hand the script a fresh module while an enabled widget
+    keeps the old object. That is a real divergence, not a theoretical one:
+    ``HeroAI.cache_data`` holds module-level cache state and is imported by both
+    CombatPrep and EZ Cast.
+    """
+    roots = tuple(reload_roots)
+    out = set()
+    for current, dirs, files in os.walk(widgets_path):
+        if ".widget" not in files:
+            continue
+        for name in files:
+            if not name.endswith(".py"):
+                continue
+            for module in imports_in(os.path.join(current, name)):
+                if module.split(".")[0] in roots:
+                    out.add(module)
+    return out
+
+
+def expand(names: set) -> set:
+    """Include submodules, so protecting HeroAI.cache_data also protects its children."""
+    out = set(names)
+    for name in list(names):
+        out.update(k for k in sys.modules if k.startswith(name + "."))
+    return out
+
+
+class ScriptLoader:
+    """Imports scripts by path, dropping their reloadable dependencies first."""
+
+    def __init__(self, widgets_path: str = "Widgets", reload_roots=RELOAD_ROOTS):
+        self.widgets_path = widgets_path
+        self.reload_roots = tuple(reload_roots)
+        self.protected = None
+        self.loaded: dict = {}
+
+    def protected_modules(self) -> set:
+        if self.protected is None:
+            self.protected = shared_with_widgets(self.widgets_path, self.reload_roots)
+        return expand(self.protected)
+
+    def refresh_protected(self) -> set:
+        self.protected = None
+        return self.protected_modules()
+
+    def purgeable(self) -> list:
+        protected = self.protected_modules()
+        out = []
+        for name in list(sys.modules):
+            root = name.split(".")[0]
+            if root in PROTECTED_ROOTS or root not in self.reload_roots:
+                continue
+            if name in protected:
+                continue
+            out.append(name)
+        return sorted(out)
+
+    def purge(self) -> list:
+        dropped = self.purgeable()
+        for name in dropped:
+            sys.modules.pop(name, None)
+        return dropped
+
+    def load(self, script_id: str, path: str, reload_dependencies: bool = True):
+        """Import (or re-import) a script. Returns (module, dropped_module_names)."""
+        name = module_name_for(script_id)
+        sys.modules.pop(name, None)
+        dropped = self.purge() if reload_dependencies else []
+
+        spec = importlib.util.spec_from_file_location(name, path)
+        if spec is None or spec.loader is None:
+            raise ImportError("cannot load %s from %s" % (script_id, path))
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        try:
+            spec.loader.exec_module(module)
+        except BaseException:
+            sys.modules.pop(name, None)
+            raise
+        self.loaded[script_id] = module
+        return module, dropped
+
+    def unload(self, script_id: str) -> bool:
+        module = self.loaded.pop(script_id, None)
+        return sys.modules.pop(module_name_for(script_id), None) is not None or module is not None
+
+    def entry_points(self, module) -> dict:
+        return {
+            key: getattr(module, key)
+            for key in ("main", "draw", "update", "configure")
+            if callable(getattr(module, key, None))
+        }

--- a/Widgets/Coding/Tools/ScriptManagementSystem.py
+++ b/Widgets/Coding/Tools/ScriptManagementSystem.py
@@ -1,0 +1,176 @@
+MODULE_NAME = "Script Management System"
+MODULE_ICON = "Textures/Module_Icons/Template.png"
+OPTIONAL = True
+
+import os
+import traceback
+
+import PyImGui
+import PySystem
+
+from Py4GWCoreLib import Color
+from Py4GWCoreLib import ImGui
+from Py4GWCoreLib.py4gwcorelib_src.script_manager import ScriptRegistry
+
+SCRIPTS_PATH = "Scripts"
+RELOAD_DELAY_MS = 350
+
+registry = ScriptRegistry(SCRIPTS_PATH)
+loaded = False
+search = ""
+function_filter = 0
+launched_id = ""
+last_error = ""
+
+
+def log(message, level=None):
+    try:
+        PySystem.Console.Log(MODULE_NAME, message, level if level is not None else PySystem.Console.MessageType.Info)
+    except Exception:
+        pass
+
+
+def script_status():
+    try:
+        return str(PySystem.script_control.status())
+    except Exception as exc:
+        return "unavailable (%s)" % exc
+
+
+def resolve(path):
+    if os.path.isabs(path):
+        return path
+    return os.path.join(PySystem.Console.get_projects_path(), path)
+
+
+def launch(meta):
+    global launched_id, last_error
+    full = resolve(meta.path)
+    if not os.path.exists(full):
+        last_error = "missing: %s" % full
+        log(last_error, PySystem.Console.MessageType.Error)
+        return
+    try:
+        PySystem.script_control.defer_stop_load_and_run(full, RELOAD_DELAY_MS)
+        launched_id = meta.id
+        last_error = ""
+        log("launching %s" % meta.name)
+    except Exception as exc:
+        last_error = str(exc)
+        log("launch failed: %s" % traceback.format_exc(), PySystem.Console.MessageType.Error)
+
+
+def stop():
+    global launched_id, last_error
+    try:
+        PySystem.script_control.stop()
+        launched_id = ""
+        last_error = ""
+        log("stopped")
+    except Exception as exc:
+        last_error = str(exc)
+        log("stop failed: %s" % exc, PySystem.Console.MessageType.Error)
+
+
+def function_options():
+    return ["(all)"] + registry.functions()
+
+
+def visible_scripts():
+    options = function_options()
+    chosen = options[function_filter] if 0 <= function_filter < len(options) else "(all)"
+    return registry.query(function="" if chosen == "(all)" else chosen, text=search)
+
+
+def draw_toolbar():
+    global search, function_filter
+
+    if PyImGui.button("Refresh##sr"):
+        registry.refresh()
+    PyImGui.same_line(0.0, 6.0)
+    if registry.changed_on_disk():
+        PyImGui.text_colored("changed on disk", Color(255, 200, 100, 255).to_tuple_normalized())
+    else:
+        PyImGui.text("%d script(s)" % len(registry.scripts))
+
+    search = PyImGui.input_text("Search##sr", search)
+    function_filter = PyImGui.combo("Function##sr", function_filter, function_options())
+
+
+def draw_row(meta):
+    running = meta.id == launched_id
+    label = ("> " if running else "  ") + meta.name
+    if PyImGui.selectable(label + "##sr_" + meta.id, running):
+        launch(meta)
+    if PyImGui.is_item_hovered():
+        PyImGui.begin_tooltip()
+        PyImGui.text(meta.name)
+        PyImGui.separator()
+        PyImGui.text("function: %s" % (meta.function or "-"))
+        PyImGui.text("tags:     %s" % (" ".join(meta.tags) or "-"))
+        PyImGui.text("claims:   %s" % (" ".join(meta.claims) or "none"))
+        PyImGui.text("path:     %s" % meta.path)
+        if meta.error:
+            PyImGui.separator()
+            PyImGui.text_colored("error: %s" % meta.error, Color(255, 120, 120, 255).to_tuple_normalized())
+        PyImGui.end_tooltip()
+
+
+def draw_widget():
+    if not ImGui.Begin("", MODULE_NAME, flags=PyImGui.WindowFlags.AlwaysAutoResize):
+        ImGui.End("")
+        return
+
+    PyImGui.text("Console: %s" % script_status())
+    if launched_id:
+        PyImGui.text("Launched: %s" % launched_id)
+    if last_error:
+        PyImGui.text_colored(last_error, Color(255, 120, 120, 255).to_tuple_normalized())
+
+    if PyImGui.button("Stop##sr"):
+        stop()
+    PyImGui.separator()
+
+    draw_toolbar()
+    PyImGui.separator()
+
+    scripts = visible_scripts()
+    if not scripts:
+        PyImGui.text("<no scripts>")
+    if PyImGui.begin_child("sr_list", (420.0, 260.0), 1, 0):
+        for meta in scripts:
+            draw_row(meta)
+    PyImGui.end_child()
+
+    errors = registry.errors()
+    if errors:
+        PyImGui.separator()
+        PyImGui.text_colored(
+            "%d script(s) with bad metadata" % len(errors), Color(255, 120, 120, 255).to_tuple_normalized()
+        )
+
+    ImGui.End("")
+
+
+def tooltip():
+    PyImGui.begin_tooltip()
+    PyImGui.text_colored(MODULE_NAME, Color(255, 200, 100, 255).to_tuple_normalized())
+    PyImGui.separator()
+    PyImGui.text_wrapped("Browse and launch scripts from Scripts/ by their declared metadata.")
+    PyImGui.bullet_text("Filter by function, search by name.")
+    PyImGui.bullet_text("Launches through PySystem.script_control (one script at a time).")
+    PyImGui.bullet_text("Refresh re-reads metadata without importing anything.")
+    PyImGui.end_tooltip()
+
+
+def main():
+    global loaded
+    if not loaded:
+        registry.reload()
+        loaded = True
+        log("discovered %d script(s) in %s" % (len(registry.scripts), SCRIPTS_PATH))
+    draw_widget()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/SCRIPT_MIGRATION_LIST.md
+++ b/docs/SCRIPT_MIGRATION_LIST.md
@@ -1,0 +1,191 @@
+# Script migration list
+
+All 179 modules are currently **widgets**. This is the candidate list for moving them to
+`Scripts/` one at a time. Nothing here is done yet.
+
+Ordering is lowest-risk first: no `__file__` use, no path derivation, no sibling assets.
+Rows with a **risk** entry need a look before moving -- that column is what broke things
+in the bulk trial run.
+
+## Process per script
+
+1. Add the `__script__` block shown in the row
+2. `git mv` the file to `Scripts/<name>.py` (flat -- no subfolders)
+3. Move any listed sibling assets alongside it
+4. Remove the folder's `.widget` marker if no `.py` remains
+5. Verify with the registry: metadata extracts, imports resolve
+
+## Candidates (146)
+
+| # | id | function | tags | claims | loc | risk | current path |
+|---|---|---|---|---|---|---|---|
+| 1 | `packetsniffertester` | debug | - | **none** | 146 | - | `Coding/Debug/Guild Wars/PacketSnifferTester.py` |
+| 2 | `resolve_catalog_text` | debug | - | **none** | 156 | - | `Coding/Debug/Py4GW/Resolve Catalog Text.py` |
+| 3 | `ui_listener` | debug | - | **none** | 177 | - | `Coding/Debug/Guild Wars/UI_Listener.py` |
+| 4 | `dump_named_mod_table` | debug | - | **none** | 179 | - | `Coding/Debug/Py4GW/Dump Named Mod Table.py` |
+| 5 | `callback_monitor` | debug | - | **none** | 185 | - | `Coding/Debug/Py4GW/Callback Monitor.py` |
+| 6 | `mod_discovery` | debug | - | **none** | 195 | - | `Coding/Debug/Py4GW/Mod Discovery.py` |
+| 7 | `mod_parity_scan` | debug | - | **none** | 201 | - | `Coding/Debug/Py4GW/Mod Parity Scan.py` |
+| 8 | `resolve_mod_tables` | debug | - | **none** | 229 | - | `Coding/Debug/Py4GW/Resolve Mod Tables.py` |
+| 9 | `dump_item_catalogs` | debug | - | **none** | 259 | - | `Coding/Debug/Py4GW/Dump Item Catalogs.py` |
+| 10 | `sharedmem_isolation_manager` | debug | - | **sharedmem** | 308 | - | `Coding/Debug/Py4GW/SharedMem Isolation Manager.py` |
+| 11 | `item_mods_playground` | debug | - | **inventory** | 381 | - | `Coding/Debug/Py4GW/Item Mods Playground.py` |
+| 12 | `frame_tester` | debug | - | **none** | 483 | - | `Coding/Debug/Guild Wars/Frame_Tester.py` |
+| 13 | `accountdata` | debug | - | **skills** | 530 | - | `Coding/Debug/Guild Wars/AccountData.py` |
+| 14 | `agent_info` | debug | - | **none** | 597 | - | `Coding/Debug/Guild Wars/Agent Info.py` |
+| 15 | `quest_data` | debug | - | **none** | 634 | - | `Coding/Debug/Guild Wars/Quest Data.py` |
+| 16 | `rawframe_tester` | debug | - | **none** | 810 | - | `Coding/Debug/Guild Wars/RawFrame_Tester.py` |
+| 17 | `system_monitor` | debug | - | **none** | 849 | - | `Coding/Debug/Py4GW/System Monitor.py` |
+| 18 | `gameconfigviewer` | debug | - | **none** | 854 | - | `Coding/Debug/Guild Wars/GameConfigViewer.py` |
+| 19 | `sharedmem_monitor` | debug | - | **none** | 1045 | - | `Coding/Debug/Py4GW/SharedMem Monitor.py` |
+| 20 | `combateventstester` | debug | - | **skills** | 1188 | - | `Coding/Debug/Guild Wars/CombatEventsTester.py` |
+| 21 | `frame_showcase` | debug | - | **none** | 1351 | - | `Coding/Debug/Guild Wars/Frame_Showcase.py` |
+| 22 | `skill_trainer` | dialog | - | **dialog** | 33 | - | `Automation/Helpers/Dialogs/Skill Trainer.py` |
+| 23 | `profession_unlocker` | dialog | - | **dialog inventory** | 233 | - | `Automation/Helpers/Dialogs/Profession Unlocker.py` |
+| 24 | `snowball_dominance` | event | - | **character inventory** | 575 | - | `Automation/Bots/Events/Winter/snowball_dominance.py` |
+| 25 | `rollerbeetle_racing` | event | - | **character inventory** | 624 | - | `Automation/Bots/Events/Rollerbeetle Racing.py` |
+| 26 | `imgui_official_demo` | example | - | **none** | 47 | - | `Coding/ImGui/ImGui Official DEMO.py` |
+| 27 | `floatingicon_example` | example | - | **none** | 89 | - | `Coding/Examples/FloatingIcon example.py` |
+| 28 | `color_picker` | example | - | **none** | 95 | - | `Coding/ImGui/Color Picker.py` |
+| 29 | `color_pallete` | example | - | **none** | 135 | - | `Coding/ImGui/Color Pallete.py` |
+| 30 | `icon_explorer` | example | - | **none** | 206 | - | `Coding/ImGui/Icon Explorer.py` |
+| 31 | `pathplanner` | example | - | **character** | 218 | - | `Coding/Examples/Pathing/PathPlanner.py` |
+| 32 | `scanner_test` | example | - | **none** | 350 | - | `Coding/Examples/Low Level/Scanner Test.py` |
+| 33 | `skillinfo` | example | - | **skills** | 686 | - | `Coding/Examples/Skills/SkillInfo.py` |
+| 34 | `gold_crimson_skull` | farmer | nicholas trophie | **character** | 50 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Gold Crimson Skull.py` |
+| 35 | `jade_bracelet` | farmer | nicholas trophie | **character** | 57 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Jade Bracelet.py` |
+| 36 | `behemoth_hides` | farmer | nicholas trophie | **character** | 59 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Behemoth Hides.py` |
+| 37 | `skull_juju` | farmer | nicholas trophie | **character** | 60 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Skull Juju.py` |
+| 38 | `truffle` | farmer | nicholas trophie | **character** | 62 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Truffle.py` |
+| 39 | `putrid_cyst` | farmer | nicholas trophie | **character** | 63 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Putrid Cyst.py` |
+| 40 | `mandragor_swamproot` | farmer | nicholas trophie | **character** | 64 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Mandragor Swamproot.py` |
+| 41 | `kath_hammers` | farmer | - | **character** | 64 | - | `Automation/Bots/Miscellaneous/kath_hammers.py` |
+| 42 | `dragon_root` | farmer | nicholas trophie | **character** | 65 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Dragon Root.py` |
+| 43 | `maguuma_mane` | farmer | nicholas trophie | **character** | 68 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Maguuma Mane.py` |
+| 44 | `minotaur_horn_farm` | farmer | nicholas trophie | **character** | 69 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Minotaur Horn Farm.py` |
+| 45 | `frosted_griffon_wing` | farmer | nicholas trophie | **character** | 70 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Frosted Griffon Wing.py` |
+| 46 | `jade_mandible` | farmer | nicholas trophie | **character** | 70 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Jade Mandible.py` |
+| 47 | `spiked_crest` | farmer | nicholas trophie | **character** | 70 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Spiked Crest.py` |
+| 48 | `glowing_heart` | farmer | nicholas trophie | **character** | 73 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Glowing Heart.py` |
+| 49 | `berserker_horn` | farmer | nicholas trophie | **character** | 75 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Berserker Horn.py` |
+| 50 | `chunk_of_drake_flesh` | farmer | nicholas trophie | **character** | 75 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Chunk of Drake Flesh.py` |
+| 51 | `eye_of_argon` | farmer | green shield weapon | **character** | 76 | - | `Automation/Bots/Farmers/Weapons/Green_Unique/Shield/Eye of Argon.py` |
+| 52 | `frigid_heart` | farmer | nicholas trophie | **character** | 80 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Frigid Heart.py` |
+| 53 | `intricate_grawl_necklace` | farmer | nicholas trophie | **character** | 80 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Intricate Grawl Necklace.py` |
+| 54 | `saurian_bone` | farmer | nicholas trophie | **character** | 80 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Saurian Bone.py` |
+| 55 | `behemoth_jaw` | farmer | nicholas trophie | **character** | 82 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Behemoth Jaw.py` |
+| 56 | `silver_bullion_coin` | farmer | nicholas trophie | **character** | 82 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Silver Bullion Coin.py` |
+| 57 | `shriveled_eye` | farmer | nicholas trophie | **character** | 95 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Shriveled Eye.py` |
+| 58 | `skelk_claw` | farmer | nicholas trophie | **character** | 95 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Skelk Claw.py` |
+| 59 | `gold_doubloon` | farmer | nicholas trophie | **character** | 105 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Gold Doubloon.py` |
+| 60 | `kaolin_wand` | farmer | green wand weapon | **character** | 105 | - | `Automation/Bots/Farmers/Weapons/Green_Unique/Wand/Kaolin Wand.py` |
+| 61 | `ssaresh_s_kris_daggers` | farmer | dagger green weapon | **character** | 109 | - | `Automation/Bots/Farmers/Weapons/Green_Unique/Dagger/Ssaresh's Kris Daggers.py` |
+| 62 | `exuro_s_will` | farmer | green staff weapon | **character** | 112 | - | `Automation/Bots/Farmers/Weapons/Green_Unique/Staff/Exuro's Will.py` |
+| 63 | `kepkhet_s_refuge` | farmer | green staff weapon | **character** | 113 | - | `Automation/Bots/Farmers/Weapons/Green_Unique/Staff/Kepkhet's Refuge.py` |
+| 64 | `the_scar_eater` | farmer | green staff weapon | **character** | 113 | - | `Automation/Bots/Farmers/Weapons/Green_Unique/Staff/The Scar Eater.py` |
+| 65 | `confessors_orders_exchange` | farmer | trophie warsupply | **character inventory** | 118 | - | `Automation/Bots/Farmers/Trophies/War Supply/Confessors Orders Exchange.py` |
+| 66 | `brightclaw` | farmer | green wand weapon | **character** | 121 | - | `Automation/Bots/Farmers/Weapons/Green_Unique/Wand/Brightclaw.py` |
+| 67 | `ice_breaker` | farmer | green hammer weapon | **character** | 126 | - | `Automation/Bots/Farmers/Weapons/Green_Unique/Hammer/Ice Breaker.py` |
+| 68 | `rajazan_s_fervor` | farmer | green sword weapon | **character** | 127 | - | `Automation/Bots/Farmers/Weapons/Green_Unique/Sword/Rajazan's Fervor.py` |
+| 69 | `dessicated_hydra_claws` | farmer | nicholas trophie | **character** | 140 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Dessicated Hydra Claws.py` |
+| 70 | `charr_farmer` | farmer | presearing trophie | **character inventory** | 144 | - | `Automation/Bots/Farmers/Trophies/PreAscalon/Charr Farmer.py` |
+| 71 | `totem_axe` | farmer | axe green weapon | **character** | 156 | - | `Automation/Bots/Farmers/Weapons/Green_Unique/Axe/Totem Axe.py` |
+| 72 | `icy_dragon_sword` | farmer | skin sword weapon | **character** | 167 | - | `Automation/Bots/Farmers/Weapons/Cool Skins/Sword/Icy Dragon Sword.py` |
+| 73 | `asterius_scythe` | farmer | green scythe weapon | **character** | 214 | - | `Automation/Bots/Farmers/Weapons/Green_Unique/Scythe/Asterius Scythe.py` |
+| 74 | `briahns_guidance` | farmer | green shield weapon | **character** | 231 | - | `Automation/Bots/Farmers/Weapons/Green_Unique/Shield/Briahns Guidance.py` |
+| 75 | `keen_oni_talon` | farmer | nicholas trophie | **character** | 261 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Keen Oni Talon.py` |
+| 76 | `hardened_hump` | farmer | nicholas trophie | **character** | 268 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Hardened Hump.py` |
+| 77 | `pile_of_elemental_dust` | farmer | nicholas trophie | **character** | 270 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Pile Of Elemental Dust.py` |
+| 78 | `icy_lodestone` | farmer | nicholas trophie | **character** | 283 | - | `Automation/Bots/Farmers/Trophies/Nicholas the Traveler/Icy Lodestone.py` |
+| 79 | `crystalline_sword` | farmer | skin sword weapon | **character** | 289 | - | `Automation/Bots/Farmers/Weapons/Cool Skins/Sword/Crystalline Sword.py` |
+| 80 | `proof_of_legend_bot_faction_edition` | farmer | trophie | **character inventory** | 497 | - | `Automation/Bots/Farmers/Trophies/Proof of Legend bot Faction edition.py` |
+| 81 | `yavb_2_0` | farmer | - | **character inventory** | 615 | - | `Automation/Bots/Farmers/Events/YAVB 2.0.py` |
+| 82 | `proof_of_legend_bot_3_0_nightfall_edition_by_wick_divinus` | farmer | nightfall trophie | **character** | 710 | - | `Automation/Bots/Farmers/Trophies/Proof of Legend bot 3.0 Nightfall edition by Wick Divinus.py` |
+| 83 | `tower_of_courage_farmer` | farmer | material | **character inventory** | 1089 | - | `Automation/Bots/Farmers/Materials/Obsidian Shards/tower_of_courage_farmer.py` |
+| 84 | `heartsofthenorth` | farmer | trophie warsupply | **character inventory** | 1485 | - | `Automation/Bots/Farmers/Trophies/War Supply/HeartsOfTheNorth.py` |
+| 85 | `cof_bone_farmer` | farmer | material | **character inventory** | 1713 | - | `Automation/Bots/Farmers/Materials/Bones/cof_bone_farmer.py` |
+| 86 | `dragon_moss_fiber_farmer` | farmer | material | **character inventory** | 2297 | - | `Automation/Bots/Farmers/Materials/fiber/dragon moss fiber farmer.py` |
+| 87 | `item_eater` | inventory | - | **inventory** | 87 | - | `Guild Wars/Items & Loot/item_eater.py` |
+| 88 | `superitemeater` | inventory | - | **inventory** | 627 | - | `Guild Wars/Items & Loot/SuperItemEater.py` |
+| 89 | `kilroy_stonekins_punch_out_extravaganza` | leveler | - | **character** | 117 | - | `Automation/Bots/Levelers/KillroyStoneskin/Kilroy Stonekins Punch-Out Extravaganza.py` |
+| 90 | `farmer_hamnet_bot` | leveler | - | **character inventory** | 453 | - | `Automation/Bots/Levelers/Farmer Hamnet Bot.py` |
+| 91 | `nightfall_leveler` | leveler | nightfall | **character inventory** | 2055 | - | `Automation/Bots/Levelers/Nightfall/Nightfall_leveler.py` |
+| 92 | `factions_character_leveler` | leveler | factions | **character inventory** | 2719 | - | `Automation/Bots/Levelers/Factions/Factions Character Leveler.py` |
+| 93 | `py4gw_ldoa` | leveler | prophecies | **character inventory** | 3564 | - | `Automation/Bots/Levelers/Prophecies/Py4GW - LDoA.py` |
+| 94 | `tihark_orchard` | mission | nightfall | **character** | 116 | - | `Automation/Bots/Missions/NightFall/Tihark Orchard.py` |
+| 95 | `chahbek_village_zm` | mission | nightfall | **character inventory** | 661 | - | `Automation/Bots/Missions/NightFall/Chahbek Village ZM.py` |
+| 96 | `zaishen_bounty` | mission | - | **character** | 685 | - | `Automation/Bots/Missions/Zaishen_Bounty.py` |
+| 97 | `legendary_guardian` | mission | - | **character** | 1587 | - | `Automation/Bots/Missions/Legendary Guardian.py` |
+| 98 | `underworld` | mission | core | **character inventory** | 3261 | - | `Automation/Bots/Missions/Core/Underworld.py` |
+| 99 | `sulfurous_runner` | runner | - | **character** | 104 | - | `Automation/Bots/Runners/Sulfurous Runner.py` |
+| 100 | `outpostrunnerv2` | runner | - | **character** | 374 | - | `Automation/Bots/Runners/OutpostRunnerV2.py` |
+| 101 | `pongmei_chestrun` | runner | chest | **character inventory** | 381 | - | `Automation/Bots/Runners/Chest/Pongmei chestrun.py` |
+| 102 | `barbarous_shore_chestrun` | runner | chest | **character inventory** | 420 | - | `Automation/Bots/Runners/Chest/Barbarous_Shore_Chestrun.py` |
+| 103 | `hells_precipice_chestrun` | runner | chest | **character inventory** | 452 | - | `Automation/Bots/Runners/Chest/Hells_Precipice_Chestrun.py` |
+| 104 | `modular_coder` | tool | - | **none** | 35 | - | `Automation/modular/Modular Coder.py` |
+| 105 | `disable_camera_smoothing` | tool | - | **ui** | 43 | - | `Guild Wars/Customization/Disable Camera Smoothing.py` |
+| 106 | `window_renamer` | tool | - | **ui** | 54 | - | `Guild Wars/Customization/Window Renamer.py` |
+| 107 | `close_rejoinable` | tool | - | **ui** | 124 | - | `Coding/Tools/Close Rejoinable.py` |
+| 108 | `native_button_test_harness` | tool | - | **none** | 496 | - | `Coding/Tools/Native Button Test Harness.py` |
+| 109 | `layout_manager` | tool | - | **ui** | 696 | - | `Guild Wars/Customization/Layout Manager.py` |
+| 110 | `modular_tester` | tool | - | **character** | 910 | - | `Automation/modular/Modular Tester.py` |
+| 111 | `bridge_client` | tool | - | **inventory skills** | 1106 | - | `Coding/Tools/Bridge Client.py` |
+| 112 | `route_builder` | tool | - | **character** | 1392 | - | `Coding/Tools/Route Builder.py` |
+| 113 | `py4gw_demo` | tool | - | **character inventory** | 2778 | - | `Coding/Py4GW_DEMO.py` |
+| 114 | `drazach_thicket` | vanquish | factions | **character** | 362 | - | `Automation/Bots/Vanquish/Factions/Echovald Forest/Drazach Thicket.py` |
+| 115 | `ferndale` | vanquish | factions | **character** | 364 | - | `Automation/Bots/Vanquish/Factions/Echovald Forest/Ferndale.py` |
+| 116 | `morostav_trail` | vanquish | factions | **character** | 367 | - | `Automation/Bots/Vanquish/Factions/Echovald Forest/Morostav Trail.py` |
+| 117 | `pyquishai` | vanquish | - | **character** | 845 | - | `Automation/Bots/Vanquish/PyQuishAI.py` |
+| 118 | `simple_vanquish` | vanquish | - | **character** | 945 | - | `Automation/Bots/Vanquish/Simple_Vanquish.py` |
+| 119 | `eliteskillscapture` | capture | - | **character inventory** | 12617 | __file__ path-derive | `Automation/Helpers/Elite Skills/EliteSkillsCapture.py` |
+| 120 | `canthadialogsender` | dialog | factions | **dialog** | 237 | __file__ path-derive | `Automation/Helpers/Dialogs/CanthaDialogSender.py` |
+| 121 | `nfdialogsender` | dialog | - | **dialog** | 336 | __file__ path-derive | `Automation/Helpers/Dialogs/NFDialogSender.py` |
+| 122 | `balthazar_skill_unlock` | dialog | - | **dialog** | 566 | __file__ path-derive | `Automation/Helpers/Dialogs/Balthazar Skill Unlock.py` |
+| 123 | `terob` | farmer | green wand weapon | **character** | 98 | path-derive | `Automation/Bots/Farmers/Weapons/Green_Unique/Wand/Terob.py` |
+| 124 | `darkroot` | farmer | dagger green weapon | **character** | 99 | path-derive | `Automation/Bots/Farmers/Weapons/Green_Unique/Dagger/Darkroot.py` |
+| 125 | `focus_of_hanaku` | farmer | focus green weapon | **character** | 99 | path-derive | `Automation/Bots/Farmers/Weapons/Green_Unique/Focus/Focus of Hanaku.py` |
+| 126 | `wingstorm` | farmer | green wand weapon | **character** | 107 | path-derive | `Automation/Bots/Farmers/Weapons/Green_Unique/Wand/Wingstorm.py` |
+| 127 | `the_mindsquall` | farmer | focus green weapon | **character** | 110 | path-derive | `Automation/Bots/Farmers/Weapons/Green_Unique/Focus/The Mindsquall.py` |
+| 128 | `sunspear_title_farm` | farmer | nightfall title | **character** | 695 | __file__ path-derive assets:Asura Title Farm Heroes.json | `Automation/Bots/Farmers/Titles/Sunspear title farm.py` |
+| 129 | `lightbringer_mirroroflyss` | farmer | nightfall title | **character** | 875 | __file__ path-derive assets:Asura Title Farm Heroes.json | `Automation/Bots/Farmers/Titles/Lightbringer - MirrorOfLyss.py` |
+| 130 | `vanguard_title_farm` | farmer | eotn title | **character** | 947 | __file__ path-derive assets:Asura Title Farm Heroes.json | `Automation/Bots/Farmers/Titles/Vanguard title farm.py` |
+| 131 | `deldrimor_title_farm_by_wick_divinus` | farmer | eotn title | **character inventory** | 1411 | __file__ path-derive assets:Asura Title Farm Heroes.json | `Automation/Bots/Farmers/Titles/Deldrimor title farm by Wick Divinus.py` |
+| 132 | `asura_title_farm_by_wick_divinus` | farmer | eotn title | **character inventory** | 1552 | __file__ path-derive assets:Asura Title Farm Heroes.json | `Automation/Bots/Farmers/Titles/Asura title farm by Wick Divinus.py` |
+| 133 | `norn_title_farmer_by_wick_divinus` | farmer | eotn title | **character inventory** | 1707 | __file__ path-derive assets:Asura Title Farm Heroes.json | `Automation/Bots/Farmers/Titles/Norn title farmer by Wick Divinus.py` |
+| 134 | `kamadan_trade_spammer` | helper | - | **character** | 483 | __file__ assets:Kamadan Trade Spammer.ini | `Automation/Enhancements/Kamadan Trade Spammer.py` |
+| 135 | `dhuum_helper` | helper | - | **character inventory** | 571 | assets:Kamadan Trade Spammer.ini | `Automation/Enhancements/Dhuum Helper.py` |
+| 136 | `inventoryplus` | inventory | - | **inventory** | 3085 | __file__ path-derive | `Guild Wars/Items & Loot/InventoryPlus.py` |
+| 137 | `xunlaimanager` | inventory | - | **inventory** | 3400 | path-derive | `Guild Wars/Items & Loot/Xunlaimanager.py` |
+| 138 | `merchantrules` | inventory | - | **inventory** | 30378 | path-derive | `Guild Wars/Items & Loot/MerchantRules.py` |
+| 139 | `polymock` | minigame | - | **character** | 78 | __file__ path-derive | `Automation/Bots/Miscellaneous/Polymock.py` |
+| 140 | `frog_scepter_bot` | mission | dungeon | **character inventory** | 2927 | path-derive assets:bds.png,Frog Scepter.png | `Automation/Bots/Missions/Dungeons/Frog Scepter bot.py` |
+| 141 | `soo` | mission | dungeon | **character inventory** | 3429 | path-derive assets:bds.png,Frog Scepter.png | `Automation/Bots/Missions/Dungeons/SoO.py` |
+| 142 | `quest_auto_runner_simple` | runner | - | **character inventory** | 812 | path-derive | `Automation/Bots/Runners/Quest Auto-Runner (Simple).py` |
+| 143 | `outpostrunner_v1_0` | runner | - | **character** | 907 | path-derive | `Automation/Bots/Runners/Outpostrunner v1.0.py` |
+| 144 | `script_runner` | tool | - | **none** | 282 | path-derive | `Coding/Tools/Script Runner.py` |
+| 145 | `heroai_skill_editor` | tool | - | **skills** | 2179 | __file__ | `Guild Wars/Customization/HeroAi Skill Editor.py` |
+| 146 | `mount_qinkai` | vanquish | factions | **character inventory** | 1566 | __file__ path-derive | `Automation/Bots/Vanquish/Factions/The Jade Sea/Mount Qinkai.py` |
+
+## Staying as widgets (33)
+
+`action_queue_monitor`, `active_dialog_viewer`, `calendar`, `chatcommandbroadcast`, `combatprep`, `debug_terminal`, `disable_alcohol_effect`, `enemy_tracker`, `environment_upkeeper`, `ez_cast`, `frame_limiter`, `heroai`, `herohelper`, `heroic_refrain`, `instance_timer`, `lootmanager`, `map_overlay`, `messaging`, `multiboxing`, `partyquestlog`, `pet_helper`, `pycons`, `skillbar`, `style_manager`, `survival_title_helper`, `switch_character`, `system_settings`, `teaminventoryviewer`, `titlehelper`, `titles`, `travel`, `vanquish_tracker`, `widgettemplate`
+
+## Vocabulary
+
+`character` `inventory` `skills` `dialog` `ui` `sharedmem`
+
+Arbitration: two scripts claiming the same resource cannot co-run.
+`character` subsumes `dialog`, so a bot excludes dialog senders.
+
+## Known issues found during the trial run
+
+- `Widgets/Automation/Bots/Farmers/Weapons/Green_Unique/Bow/Chiggen's Shortbow` is a
+  working bot **missing its `.py` extension**, so discovery has never seen it.
+- `GTOB killer.py` and `EOTN_SKILL_UNLOCKER.py` sit in folders with no `.widget`
+  marker, so they are also undiscovered.
+- `EOTN_SKILL_UNLOCKER.py` reads `ICONS_PATH` from `Bots/SkillsUnlocker/icons`, which
+  is empty; its icons are at `Widgets/Automation/Bots/SkillsUnlocker/icons`.
+- The `update_ownership` hook splits filenames on spaces and writes truncated entries
+  (`Monitor.py`, `Info.py`) into `.vscode/settings.json`. Pre-existing.
+- Widget discovery imports every module it finds (`Widget.__post_init__` calls
+  `load_module`), so all 179 execute at boot.


### PR DESCRIPTION
> **Draft — work in progress.** The widget and the runner wiring are still being
> built out. Opening this early to make the design reviewable and to have a place
> to collect feedback. Active development continues on my `HEROAI_MIGRATION`
> branch; this branch gets re-cut from it as things stabilise, so expect
> force-pushes rather than incremental commits.

Groundwork for moving runnable scripts out of `Widgets/` into a flat `Scripts/`
directory with declarative metadata. **Nothing is migrated in this PR** — it lands
the machinery and the candidate inventory only, so it is additive and inert:
no existing widget changes behaviour.

## Why

Widget discovery imports every module it finds (`Widget.__post_init__` calls
`load_module`), so all 179 modules execute at boot whether or not you use them. A
one-shot bot or debug tool does not need to be a widget — it needs to be launchable,
introspectable before launch, and reloadable without restarting the session.

## What's here

### `script_manager/discovery.py` — the registry

`ScriptRegistry` reads a literal `__script__` dict from each script **without
importing the module**, so a rescan cannot execute script code.

- Reads only the first 8 KB of each file. A rescan over 150 scripts costs ~18 ms,
  against ~3 s for a full `ast.parse` of every module.
- `refresh()` re-reads only files whose mtime moved; `changed_on_disk()` answers the
  same question with no side effects, so the UI can badge "reload available" without
  reloading.
- A running script is **pinned** — its already-imported module stays authoritative
  until it stops, and the registry marks it stale instead of swapping underneath it.
- The `__script__` block is brace-matched rather than scanned to the next `}`, so
  nested dicts and braces inside string values do not truncate it.
- Stdlib-only, no Py4GW or ImGui imports, so it stays unit-testable outside the game
  process — same contract as `launch_bar.model`.

### `script_manager/loader.py` — dependency-aware reload

Re-importing a script does not pick up edits to the code it imports; those modules
stay cached in `sys.modules`. `ScriptLoader` drops a script's supporting modules
first.

What may be dropped is deliberately narrow, and this is the part most worth
reviewing:

- Only project code under `RELOAD_ROOTS` (`Sources`, `HeroAI`, `Bots`, `bot_factory`).
- `PROTECTED_ROOTS` is never dropped — `Py4GWCoreLib` alone has ~620 import sites and
  is imported by every widget; dropping it mid-session would leave live widgets
  holding a half-replaced library.
- `shared_with_widgets()` additionally protects anything an enabled widget imports.
  Not theoretical: `HeroAI.cache_data` holds module-level cache state and is imported
  by both CombatPrep and EZ Cast, so dropping it would hand the script a fresh module
  while the widgets keep the old object.

### `Widgets/Coding/Tools/ScriptManagementSystem.py` — the UI

Browse / filter / launch against the registry via `PySystem.script_control`. This is
the least finished piece.

### `docs/SCRIPT_MIGRATION_LIST.md` — the inventory

All 179 current modules triaged: 146 migration candidates ordered lowest-risk first,
33 that should stay widgets. The risk column flags `__file__` use, path derivation
and sibling assets — that column is what broke things in a bulk trial run.

It also records four pre-existing bugs the survey turned up, unrelated to this PR:

- `Widgets/.../Bow/Chiggen's Shortbow` is a working bot **missing its `.py`
  extension**, so discovery has never seen it.
- `GTOB killer.py` and `EOTN_SKILL_UNLOCKER.py` sit in folders with no `.widget`
  marker and are likewise undiscovered.
- `EOTN_SKILL_UNLOCKER.py` reads `ICONS_PATH` from an empty `Bots/SkillsUnlocker/icons`;
  its icons are at `Widgets/Automation/Bots/SkillsUnlocker/icons`.
- The `update_ownership` hook splits filenames on spaces and writes truncated entries
  (`Monitor.py`, `Info.py`) into `.vscode/settings.json`.

## Resource claims

Scripts declare what they drive: `character` `inventory` `skills` `dialog` `ui`
`sharedmem`. Two scripts claiming the same resource cannot co-run. `character`
subsumes `dialog`, so a bot excludes dialog senders even though it never declares
`dialog` itself.

## Known gaps — the WIP parts

- **`ScriptLoader` is not wired to the widget yet.** It is implemented and tested,
  but the widget currently launches through `PySystem.script_control` and does not go
  through the loader. Connecting the two is the next piece of work.
- **`Scripts/` lands empty.** The first migrated script (`DervCOFFarmBT.py`) depends
  on unmerged work on my branch, so it is deliberately held back rather than dragging
  those dependencies in here. `ScriptRegistry` handles a missing or empty root, so
  the widget renders an empty list rather than erroring.
- No migration has been performed. `SCRIPT_MIGRATION_LIST.md` says "nothing here is
  done yet" and that is accurate.

## Verification

- `pyflakes` clean on both new modules and the widget.
- Byte-compiles under `.venv/Scripts/python.exe` (3.13.0, 32-bit).
- Both modules are covered by a 35-case unit suite held back on my working branch
  while the API is still moving — `discovery.py` and `loader.py` are stdlib-only
  precisely so they stay testable outside the game process. Happy to bring the suite
  into this PR if you'd want it landed alongside; the repo has no test runner
  configured today, so I left that call to you rather than assuming a convention.

Additive only: no existing file is modified, no persistence changes, no new
dependencies.
