### PR TITLE
Steam login support (real launch/attach path) + remember window position/size

### DIFF
--- a/Py4GW_Reforged_Launcher/launcher_core/accounts_store.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/accounts_store.py
@@ -116,6 +116,8 @@ def _account_from_dict(raw: dict) -> tuple[GameProfile, dict]:
     window_lock_changes = extras.pop("window_lock_changes", False)
     window_block_inputs = extras.pop("window_block_inputs", False)
     bulk_launch_enabled = extras.pop("bulk_launch_enabled", False)
+    use_steam_login = extras.pop("use_steam_login", False)
+    steam_account_anchor = extras.pop("steam_account_anchor", "") or ""
 
     # RELAY 066 item 6: encrypt on first touch. A real plaintext `password`
     # value always wins over whatever password_protected already exists --
@@ -160,6 +162,8 @@ def _account_from_dict(raw: dict) -> tuple[GameProfile, dict]:
         window_lock_changes=bool(window_lock_changes),
         window_block_inputs=bool(window_block_inputs),
         bulk_launch_enabled=bool(bulk_launch_enabled),
+        use_steam_login=bool(use_steam_login),
+        steam_account_anchor=steam_account_anchor,
     )
     if profile_id:
         kwargs["id"] = profile_id
@@ -435,6 +439,8 @@ def _profile_to_dict(profile: GameProfile) -> dict:
             "window_lock_changes": profile.window_lock_changes,
             "window_block_inputs": profile.window_block_inputs,
             "bulk_launch_enabled": profile.bulk_launch_enabled,
+            "use_steam_login": profile.use_steam_login,
+            "steam_account_anchor": profile.steam_account_anchor,
         }
     )
     return extras

--- a/Py4GW_Reforged_Launcher/launcher_core/accounts_store.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/accounts_store.py
@@ -229,8 +229,23 @@ def _dedup_keys(p: GameProfile) -> list[tuple]:
     against TestDuplicateDedup's existing coverage (both its cases share an
     identical character_name + gw_path across listings, so exe_char alone
     already matched them -- this narrowing doesn't regress either test).
+
+    RELAY 094 follow-up: `exe_char` used to apply unconditionally, same bug
+    shape as RELAY 083's email fix above -- an empty `executable_path` isn't
+    a real distinguishing signal, it's "nothing," so any two profiles that
+    both happen to have a blank path AND a blank character_name (a Steam
+    profile, which has no use for executable_path anymore, alongside any
+    other blank/placeholder profile) produced the identical key
+    `("exe_char", "", "")` and silently merged into one on the very next
+    load -- caught live: a real "Steam" profile vanished entirely after
+    clearing its executable_path, absorbed into an unrelated blank
+    "(unnamed)" profile (confirmed via _parse_raw_traced's own trace:
+    `merged_via_key: 'exe_char'`). Guarded the same way the email key
+    already is.
     """
-    keys: list[tuple] = [("id", p.id), ("exe_char", p.executable_path, p.character_name)]
+    keys: list[tuple] = [("id", p.id)]
+    if p.executable_path:
+        keys.append(("exe_char", p.executable_path, p.character_name))
     if p.email and not p.character_name:
         keys.append(("email", p.email))
     return keys

--- a/Py4GW_Reforged_Launcher/launcher_core/gw1_launch.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/gw1_launch.py
@@ -960,6 +960,18 @@ def _launch_gw1_via_steam(
     `SteamLaunchService.cs`/`Gw1LaunchOrchestrator.cs`), so there's no
     reference implementation to port. Whatever a protected default Steam
     install actually needs here is unknown until tested for real.
+
+    `profile.executable_path` is deliberately NOT passed to
+    `_attach_to_steam_process` here -- found live: a Steam profile that had
+    ever been pointed at `steam.exe` (the old pre-toggle shortcut, or just
+    an editable field a user can drift back into out of habit) permanently
+    fails to attach, since the real discovered `Gw.exe`'s path can never
+    equal that. Apo's own confirmation that a user can only have one
+    Steam-linked account (see this repo's RELAY 094 notes) means the
+    multibox-precision reason that check exists for the direct-launch case
+    doesn't apply here -- name-plus-recency is already unambiguous for a
+    Steam-owned launch, so there's nothing this validation actually buys on
+    this path, only a way for a stale field to silently break it.
     """
     _apply_gw1_registry_fix(profile, log)
 
@@ -970,7 +982,7 @@ def _launch_gw1_via_steam(
     except OSError as e:
         return LaunchResult(False, None, f"Steam URI launch failed: {e}", log)
 
-    pid = _attach_to_steam_process(profile.executable_path, launch_timestamp, log, timeout=steam_attach_timeout)
+    pid = _attach_to_steam_process("", launch_timestamp, log, timeout=steam_attach_timeout)
     if pid is None:
         return LaunchResult(
             False, None, "Steam launch accepted, but no matching Gw.exe process was found", log
@@ -1043,19 +1055,27 @@ def launch_py4gw_profile(
     multiclient_enabled: bool = True,
     py4gw_injection_enabled: bool = True,
     gmod_injection_enabled: bool = True,
-    steam_attach_timeout: float = 5.0,
+    steam_attach_timeout: float = 30.0,
     on_log: Optional[Callable[[str], None]] = None,
 ) -> LaunchResult:
     """Launch `profile`'s executable, optionally auto-logging in, and inject Py4GW
     and/or gMod into it per the profile's own toggles.
 
     RELAY 094: if `profile.use_steam_login` is set, this dispatches entirely
-    to `_launch_gw1_via_steam` instead -- `profile.executable_path` is still
-    validated below first (same "meaningless without it" reasoning as the
-    direct path), but is used only for post-attach path verification and the
-    registry fix from that point on, never as a `CreateProcessW` target.
-    `steam_attach_timeout` (GWxLauncher parity default: 5s) only matters on
-    that path.
+    to `_launch_gw1_via_steam` instead, and skips the `executable_path`
+    requirement below -- Steam owns the actual launch, and (found live)
+    `executable_path` no longer has any real use on that path either (see
+    `_launch_gw1_via_steam`'s own docstring for why it stopped being used
+    for post-attach validation too), so requiring it here would just be an
+    artificial gate with nothing behind it. `steam_attach_timeout` only
+    matters on that path -- bumped from GWxLauncher's 5s parity default to
+    30s after a real live test: a cold Steam launch (DRM/overlay/update
+    checks before `Gw.exe` even exists as a process) can legitimately take
+    longer than 5s to spawn the process at all, well before any window-wait
+    logic even begins. Confirmed live: `_attach_to_steam_process` timed out
+    twice at 5s while Steam was still genuinely loading the game in the
+    background, and the character-select screen appeared afterward with no
+    injection ever attempted, since the launcher had already given up.
 
     `profile.py4gw_enabled`/`profile.gmod_enabled` each gate only their own
     DLL-path validation and injection call: a profile with both off still gets
@@ -1105,9 +1125,6 @@ def launch_py4gw_profile(
     """
     log: list = _ObservableLog(on_log)
 
-    if not profile.executable_path or not os.path.exists(profile.executable_path):
-        return LaunchResult(False, None, f"executable_path not found: {profile.executable_path!r}", log)
-
     if profile.use_steam_login:
         return _launch_gw1_via_steam(
             profile,
@@ -1119,6 +1136,9 @@ def launch_py4gw_profile(
             steam_attach_timeout=steam_attach_timeout,
             log=log,
         )
+
+    if not profile.executable_path or not os.path.exists(profile.executable_path):
+        return LaunchResult(False, None, f"executable_path not found: {profile.executable_path!r}", log)
 
     _apply_gw1_registry_fix(profile, log)
 

--- a/Py4GW_Reforged_Launcher/launcher_core/gw1_launch.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/gw1_launch.py
@@ -143,8 +143,27 @@ STEAM_GW1_URI = f"steam://rungameid/{STEAM_GW1_APP_ID}"
 # stays up -- a multi-minute patch just means a longer wait for this class
 # to exist, not a premature "found a window" against the splash/patch
 # dialog. Applies to both launch paths (direct and Steam) since both share
-# `_wait_for_gw_window`/`_wait_for_window_or_exit`.
+# `_wait_for_window_or_exit` (the only window-wait function left in this
+# file -- `_wait_for_gw_window` used to be a second, flat-timeout variant
+# for the Steam path and the post-respawn direct-path wait, but both call
+# sites moved onto this one during the same follow-up, since a respawned
+# process can show its own splash dialog too and deserves the same
+# patient, class-filtered wait as the first one).
 GW_MAIN_WINDOW_CLASS = "ArenaNet_Dx_Window_Class"
+
+# RELAY 094 follow-up: Chris's own live-play observation -- the splash/patch
+# dialog can close and re-open several times ("1-2 maybe 3" transitions)
+# over the course of a single patch cycle, not just once. A window closing
+# and re-opening within the *same* process is already handled for free by
+# _wait_for_window_or_exit's own polling (it re-checks GW_MAIN_WINDOW_CLASS's
+# existence from scratch every pass, regardless of how many times the
+# dialog itself has cycled in between) -- but this pipeline's "exited"
+# branch (the Gw.tmp-style handoff: the process itself exits and a new one
+# takes over) previously only tolerated ONE such exit/respawn before giving
+# up, on both launch paths. Bumped to a bounded retry loop instead -- 5 is
+# a generous margin over Chris's own "1-2 maybe 3," not a guess pulled from
+# nowhere.
+MAX_PROCESS_RESPAWN_ATTEMPTS = 5
 
 
 def _is_gw_main_window(hwnd: int, pid: int) -> bool:
@@ -536,37 +555,6 @@ def _inject_dll(pid: int, dll_path: str, log: list) -> bool:
             kernel32.CloseHandle(process_handle)
 
 
-def _wait_for_gw_window(pid: int, log: list, timeout: float = 30.0) -> bool:
-    _log(log, f"Waiting for GW window (PID {pid})")
-    start_time = time.time()
-    found_windows = []
-
-    def enum_windows_callback(hwnd, _):
-        if _is_gw_main_window(hwnd, pid):
-            found_windows.append(hwnd)
-        return True
-
-    while time.time() - start_time < timeout:
-        try:
-            if psutil.Process(pid).status() != psutil.STATUS_RUNNING:
-                _log(log, f"Process {pid} is no longer running")
-                return False
-        except psutil.NoSuchProcess:
-            _log(log, f"Process {pid} no longer exists")
-            return False
-
-        found_windows.clear()
-        win32gui.EnumWindows(enum_windows_callback, None)
-        if found_windows:
-            _log(log, f"Found {len(found_windows)} window(s) for PID {pid}")
-            return True
-
-        time.sleep(0.5)
-
-    _log(log, f"Timed out waiting for a window from PID {pid}")
-    return False
-
-
 def _wait_for_window_or_exit(
     pid: int,
     log: list,
@@ -678,7 +666,7 @@ def _set_gw_window_title(pid: int, title: str, log: list) -> None:
             except pywintypes.error:
                 # A window can be destroyed mid-enumeration; skip it rather than
                 # letting one bad handle crash the whole enumeration (see
-                # _wait_for_gw_window/_wait_for_window_or_exit above).
+                # _is_gw_main_window/_wait_for_window_or_exit above).
                 pass
             return True
 
@@ -1057,9 +1045,28 @@ def _launch_gw1_via_steam(
     else:
         _log(log, "gMod injection disabled for this profile -- launching without it")
 
-    outcome = _wait_for_window_or_exit(pid, log, absolute_ceiling=absolute_ceiling, hang_fail_threshold=hang_fail_threshold)
+    outcome = "exited"
+    for attempt in range(MAX_PROCESS_RESPAWN_ATTEMPTS + 1):
+        outcome = _wait_for_window_or_exit(pid, log, absolute_ceiling=absolute_ceiling, hang_fail_threshold=hang_fail_threshold)
+        if outcome != "exited" or attempt == MAX_PROCESS_RESPAWN_ATTEMPTS:
+            break
+        _log(
+            log,
+            f"Process exited (possible patch-cycle restart, attempt {attempt + 1}/{MAX_PROCESS_RESPAWN_ATTEMPTS}) "
+            "-- looking for a follow-up Steam-spawned process",
+        )
+        new_pid = _attach_to_steam_process("", time.time(), log, timeout=steam_attach_timeout)
+        if new_pid is None:
+            break
+        pid = new_pid
+        if multiclient_enabled:
+            if not _apply_multiclient_patch(pid, log):
+                _log(log, "Multiclient patch on the follow-up process failed (best-effort, continuing)")
+        else:
+            _log(log, "Multiclient patch disabled (App Settings) -- skipping")
+
     if outcome == "exited":
-        return LaunchResult(False, pid, "Gw.exe exited before its main window ever appeared", log)
+        return LaunchResult(False, pid, "Gw.exe kept exiting during patch/update without ever showing its main window", log)
     elif outcome == "hung":
         return LaunchResult(False, pid, f"Window stayed hung for {hang_fail_threshold}s+; treating as stuck, not a slow update", log)
     elif outcome == "timeout":
@@ -1098,7 +1105,6 @@ def launch_py4gw_profile(
     profile: GameProfile,
     *,
     pre_injection_config: Optional[PreInjectionConfig] = None,
-    window_wait_timeout: float = 30.0,
     post_window_settle_delay: float = 5.0,
     absolute_ceiling: float = ABSOLUTE_CEILING_DEFAULT,
     hang_fail_threshold: float = HANG_FAIL_THRESHOLD_DEFAULT,
@@ -1281,16 +1287,22 @@ def launch_py4gw_profile(
     kernel32.CloseHandle(process_info.hProcess)
     kernel32.CloseHandle(process_info.hThread)
 
-    outcome = _wait_for_window_or_exit(pid, log, absolute_ceiling=absolute_ceiling, hang_fail_threshold=hang_fail_threshold)
-
-    if outcome == "exited":
+    outcome = "exited"
+    for attempt in range(MAX_PROCESS_RESPAWN_ATTEMPTS + 1):
+        outcome = _wait_for_window_or_exit(pid, log, absolute_ceiling=absolute_ceiling, hang_fail_threshold=hang_fail_threshold)
+        if outcome != "exited" or attempt == MAX_PROCESS_RESPAWN_ATTEMPTS:
+            break
+        _log(
+            log,
+            f"Process exited (possible patch-cycle restart, attempt {attempt + 1}/{MAX_PROCESS_RESPAWN_ATTEMPTS}) "
+            "-- scanning for a follow-up process",
+        )
         replacement_pid = _find_replacement_process(
             profile.executable_path, exclude_pid=pid, launched_after=launch_timestamp, log=log,
             timeout=replacement_scan_timeout,
         )
         if replacement_pid is None:
-            return LaunchResult(False, pid, "Updater process exited but no follow-up Gw.exe process was found", log)
-
+            break
         pid = replacement_pid
         if multiclient_enabled:
             if not _apply_multiclient_patch(pid, log):
@@ -1298,8 +1310,8 @@ def launch_py4gw_profile(
         else:
             _log(log, "Multiclient patch disabled (App Settings) -- skipping")
 
-        if not _wait_for_gw_window(pid, log, timeout=window_wait_timeout):
-            return LaunchResult(False, pid, "GW window never appeared", log)
+    if outcome == "exited":
+        return LaunchResult(False, pid, "Gw.exe kept exiting during update without ever showing its main window", log)
 
     elif outcome == "hung":
         return LaunchResult(False, pid, f"Window stayed hung for {hang_fail_threshold}s+; treating as stuck, not a slow update", log)

--- a/Py4GW_Reforged_Launcher/launcher_core/gw1_launch.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/gw1_launch.py
@@ -125,6 +125,11 @@ PROCESS_INJECTION_ACCESS = (
 
 CREATE_SUSPENDED = 0x00000004
 
+# RELAY 094: GW1's Steam app ID, confirmed against GWxLauncher's own
+# SteamLaunchService.Gw1SteamGameId.
+STEAM_GW1_APP_ID = "29720"
+STEAM_GW1_URI = f"steam://rungameid/{STEAM_GW1_APP_ID}"
+
 VIRTUAL_MEM = 0x1000 | 0x2000  # MEM_COMMIT | MEM_RESERVE
 PAGE_READWRITE = 0x04
 MEM_RELEASE = 0x8000
@@ -400,6 +405,36 @@ def _write_autoexec_script(script_path: str, log: list) -> None:
         _log(log, f"Could not write autoexec_script to Py4GW.ini (non-fatal): {e}")
 
 
+def _write_account_anchor(account_anchor: str, log: list) -> None:
+    """RELAY 094: writes `account_anchor` into Py4GW.ini's [settings]
+    account_anchor key, mirroring _write_autoexec_script() exactly (same
+    plain configparser read-modify-write, same best-effort/non-fatal
+    framing, same root-scoped/shared-file limitation -- moot here in
+    practice, per Apo's own confirmation a user can only have one
+    Steam-linked account, so there's nothing to race against).
+
+    Deliberately a distinct key from `email` -- Steam-linked accounts have
+    no email Py4GW can read from memory at all (Apo confirmed directly),
+    so this isn't a fallback value for that field, it's a different concept
+    entirely: an opaque anchor Py4GW_Reforged_Native's
+    System::UpdateAccountAnchor() reads to resolve the per-account settings
+    folder when the memory-based read can't run.
+    """
+    ini_path = _mod_root() / "Py4GW.ini"
+    try:
+        config = configparser.ConfigParser()
+        if ini_path.exists():
+            config.read(ini_path)
+        if not config.has_section("settings"):
+            config.add_section("settings")
+        config.set("settings", "account_anchor", account_anchor)
+        with open(ini_path, "w") as f:
+            config.write(f)
+        _log(log, f"Wrote account_anchor to {ini_path}")
+    except OSError as e:
+        _log(log, f"Could not write account_anchor to Py4GW.ini (non-fatal): {e}")
+
+
 def _inject_dll(pid: int, dll_path: str, log: list) -> bool:
     if not dll_path or not os.path.exists(dll_path):
         _log(log, f"Inject DLL - invalid DLL path: {dll_path!r}")
@@ -671,6 +706,56 @@ def _find_replacement_process(exe_path: str, exclude_pid: int, launched_after: f
     return None
 
 
+def _attach_to_steam_process(exe_path: str, launched_after: float, log: list, timeout: float = 5.0) -> Optional[int]:
+    """RELAY 094: Steam owns process creation once GW1 is launched via
+    `STEAM_GW1_URI` -- there is no suspended process handle to patch, by
+    design, not as a workaround. Ported from GWxLauncher's
+    SteamProcessAttachService.TryAttachToSteamProcess (confirmed directly
+    against Services/SteamProcessAttachService.cs): poll by process *name*
+    ("Gw"/"GW", since .NET's GetProcessesByName strips the extension) with a
+    2-second buffer against `launched_after` for clock skew, same as that
+    reference and the same buffer `_find_replacement_process` above already
+    uses for the same reason.
+
+    Adds one thing the C# reference doesn't have: once a name match is
+    found, validates its *resolved* exe path against `exe_path` before
+    accepting it. Name-only matching is fine for GWxLauncher's
+    single-account-type case, but this is a multibox tool where more than
+    one Gw.exe copy across different accounts/install folders is the normal
+    case, so precision matters more here -- an empty/unresolvable `exe_path`
+    (AccessDenied reading another user's process, or a genuinely empty
+    profile.executable_path) skips the path check rather than rejecting the
+    match outright, since name-plus-recency is still meaningfully selective
+    on its own.
+    """
+    target_path = os.path.normcase(os.path.abspath(exe_path)) if exe_path else None
+    start_time = time.time()
+
+    _log(log, f"Waiting for Steam to spawn Gw.exe (up to {timeout}s)")
+    while time.time() - start_time < timeout:
+        for proc in psutil.process_iter(["pid", "name", "exe", "create_time"]):
+            name = (proc.info["name"] or "").lower()
+            if name not in ("gw.exe", "gw"):
+                continue
+            try:
+                if proc.info["create_time"] < launched_after - 2.0:
+                    continue
+                proc_exe = proc.info["exe"]
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+
+            if target_path and proc_exe and os.path.normcase(os.path.abspath(proc_exe)) != target_path:
+                continue
+
+            _log(log, f"Found Steam-spawned process PID {proc.info['pid']}")
+            return proc.info["pid"]
+
+        time.sleep(0.2)
+
+    _log(log, f"Timed out waiting for Steam to spawn a matching Gw.exe process (after {timeout}s)")
+    return None
+
+
 def _apply_gw1_registry_fix(profile: GameProfile, log: list) -> None:
     """Writes profile.executable_path into both Path and Src under
     HKEY_CURRENT_USER\\Software\\ArenaNet\\Guild Wars before every launch --
@@ -831,6 +916,121 @@ def _redact_command_line_for_log(command_line: str) -> str:
     return re.sub(r'(-password\s+)"[^"]*"', r'\1"***"', command_line)
 
 
+def _launch_gw1_via_steam(
+    profile: GameProfile,
+    *,
+    window_wait_timeout: float,
+    post_window_settle_delay: float,
+    multiclient_enabled: bool,
+    py4gw_injection_enabled: bool,
+    gmod_injection_enabled: bool,
+    steam_attach_timeout: float,
+    log: list,
+) -> LaunchResult:
+    """RELAY 094: Steam-login launch/attach path, used instead of the direct
+    `CreateProcessW` pipeline above whenever `profile.use_steam_login` is
+    set. Steam-linked accounts have no email Py4GW can read from memory and
+    no ArenaNet credentials this launcher can auto-fill, so this path is a
+    genuinely different shape, not a variant of the direct one:
+
+    1. Launch via the `STEAM_GW1_URI` (`os.startfile`, the Python equivalent
+       of GWxLauncher's `Process.Start(UseShellExecute=true)` on the same
+       URI) -- Steam owns process creation from this point on.
+    2. Discover the real process via `_attach_to_steam_process` (polls by
+       name, not exit-then-match -- there's no PID to wait on).
+    3. Multiclient patch and gMod injection become best-effort against an
+       already-running process. Verified directly against this file's own
+       `_apply_multiclient_patch` and `_inject_dll` before assuming a new
+       patch function was needed (RELAY 094's own entry text guessed one
+       would be): neither one actually depends on the target process being
+       suspended (both just `OpenProcess` by PID and read/write/inject),
+       and this module's own docstring already documents `_apply_multiclient_patch`
+       being reused best-effort against the update-hop replacement process
+       for the exact same reason -- established precedent in this codebase,
+       not a new pattern. Reused as-is; no new function.
+    4. Py4GW injection stays conceptually the same as the direct path (wait
+       for window, settle, inject) but keys off the discovered/attached PID.
+    5. `_apply_gw1_registry_fix` still runs first -- GW1 reads that registry
+       key at startup regardless of how the process was created, so it's
+       equally relevant here.
+
+    Elevation/UAC is NOT handled here -- flagged, not solved, per this
+    entry's own instruction. GWxLauncher's own Steam path has zero
+    elevation/admin handling either (confirmed directly against
+    `SteamLaunchService.cs`/`Gw1LaunchOrchestrator.cs`), so there's no
+    reference implementation to port. Whatever a protected default Steam
+    install actually needs here is unknown until tested for real.
+    """
+    _apply_gw1_registry_fix(profile, log)
+
+    launch_timestamp = time.time()
+    _log(log, f"Launching via Steam: {STEAM_GW1_URI}")
+    try:
+        os.startfile(STEAM_GW1_URI)
+    except OSError as e:
+        return LaunchResult(False, None, f"Steam URI launch failed: {e}", log)
+
+    pid = _attach_to_steam_process(profile.executable_path, launch_timestamp, log, timeout=steam_attach_timeout)
+    if pid is None:
+        return LaunchResult(
+            False, None, "Steam launch accepted, but no matching Gw.exe process was found", log
+        )
+
+    if multiclient_enabled:
+        if not _apply_multiclient_patch(pid, log):
+            _log(log, "Multiclient patch failed (Steam best-effort -- timing window missed / access denied / incompatible state, continuing)")
+    else:
+        _log(log, "Multiclient patch disabled (App Settings) -- skipping")
+
+    will_inject_gmod = _resolve_gmod_launch_decision(profile, gmod_injection_enabled, log)
+    if will_inject_gmod:
+        try:
+            per_profile_gmod_dll = _prepare_per_profile_gmod_folder(profile)
+        except Exception as e:
+            _log(log, f"gMod per-profile folder setup failed (Steam best-effort, continuing): {e}")
+        else:
+            if _inject_dll(pid, per_profile_gmod_dll, log):
+                _log(log, "gMod DLL injection reported success")
+            else:
+                _log(log, "gMod DLL injection failed (Steam best-effort -- injection window likely missed, continuing)")
+    elif profile.gmod_enabled and gmod_injection_enabled:
+        pass  # RELAY 091: already logged the specific unresolved-path reason above.
+    elif profile.gmod_enabled and not gmod_injection_enabled:
+        _log(log, "gMod injection globally disabled (App Settings) -- launching without it")
+    else:
+        _log(log, "gMod injection disabled for this profile -- launching without it")
+
+    if not _wait_for_gw_window(pid, log, timeout=window_wait_timeout):
+        return LaunchResult(False, pid, "GW window never appeared", log)
+
+    if profile.auto_select_character_enabled and profile.character_name:
+        window_title = profile.character_name
+    else:
+        window_title = profile.name
+    _set_gw_window_title(pid, window_title, log)
+
+    if profile.py4gw_enabled and py4gw_injection_enabled:
+        _log(log, f"Window found; waiting {post_window_settle_delay}s before injecting Py4GW")
+        time.sleep(post_window_settle_delay)
+
+        if profile.script_path:
+            _write_autoexec_script(profile.script_path, log)
+
+        if profile.use_steam_login and profile.steam_account_anchor:
+            _write_account_anchor(profile.steam_account_anchor, log)
+
+        if not _inject_dll(pid, profile.py4gw_dll_path, log):
+            return LaunchResult(False, pid, "Py4GW DLL injection failed", log)
+
+        _log(log, "Py4GW DLL injection reported success")
+    elif profile.py4gw_enabled and not py4gw_injection_enabled:
+        _log(log, "Py4GW injection globally disabled (App Settings) -- launching without it")
+    else:
+        _log(log, "Py4GW injection disabled for this profile -- launching without it")
+
+    return LaunchResult(True, pid, None, log)
+
+
 def launch_py4gw_profile(
     profile: GameProfile,
     *,
@@ -843,10 +1043,19 @@ def launch_py4gw_profile(
     multiclient_enabled: bool = True,
     py4gw_injection_enabled: bool = True,
     gmod_injection_enabled: bool = True,
+    steam_attach_timeout: float = 5.0,
     on_log: Optional[Callable[[str], None]] = None,
 ) -> LaunchResult:
     """Launch `profile`'s executable, optionally auto-logging in, and inject Py4GW
     and/or gMod into it per the profile's own toggles.
+
+    RELAY 094: if `profile.use_steam_login` is set, this dispatches entirely
+    to `_launch_gw1_via_steam` instead -- `profile.executable_path` is still
+    validated below first (same "meaningless without it" reasoning as the
+    direct path), but is used only for post-attach path verification and the
+    registry fix from that point on, never as a `CreateProcessW` target.
+    `steam_attach_timeout` (GWxLauncher parity default: 5s) only matters on
+    that path.
 
     `profile.py4gw_enabled`/`profile.gmod_enabled` each gate only their own
     DLL-path validation and injection call: a profile with both off still gets
@@ -898,6 +1107,18 @@ def launch_py4gw_profile(
 
     if not profile.executable_path or not os.path.exists(profile.executable_path):
         return LaunchResult(False, None, f"executable_path not found: {profile.executable_path!r}", log)
+
+    if profile.use_steam_login:
+        return _launch_gw1_via_steam(
+            profile,
+            window_wait_timeout=window_wait_timeout,
+            post_window_settle_delay=post_window_settle_delay,
+            multiclient_enabled=multiclient_enabled,
+            py4gw_injection_enabled=py4gw_injection_enabled,
+            gmod_injection_enabled=gmod_injection_enabled,
+            steam_attach_timeout=steam_attach_timeout,
+            log=log,
+        )
 
     _apply_gw1_registry_fix(profile, log)
 
@@ -1028,6 +1249,9 @@ def launch_py4gw_profile(
 
         if profile.script_path:
             _write_autoexec_script(profile.script_path, log)
+
+        if profile.use_steam_login and profile.steam_account_anchor:
+            _write_account_anchor(profile.steam_account_anchor, log)
 
         if not _inject_dll(pid, profile.py4gw_dll_path, log):
             return LaunchResult(False, pid, "Py4GW DLL injection failed", log)

--- a/Py4GW_Reforged_Launcher/launcher_core/gw1_launch.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/gw1_launch.py
@@ -130,6 +130,40 @@ CREATE_SUSPENDED = 0x00000004
 STEAM_GW1_APP_ID = "29720"
 STEAM_GW1_URI = f"steam://rungameid/{STEAM_GW1_APP_ID}"
 
+# RELAY 094 follow-up: GW1 shows two genuinely distinct Win32 window
+# classes during startup, confirmed via a real live capture (GetClassName
+# on every new window for the launched PID, not assumed) -- the
+# splash/patch dialog is `ArenaNet_Dialog_Class` (a real window, not just a
+# transient flash: it stayed up across several observed launches, exactly
+# the thing a slow content update would keep visible for minutes), and the
+# actual 3D game client is a separate, later-appearing
+# `ArenaNet_Dx_Window_Class`. Waiting specifically for this class (see
+# `_is_gw_main_window` below), instead of "any visible window for this
+# PID," means injection timing no longer depends on how long the dialog
+# stays up -- a multi-minute patch just means a longer wait for this class
+# to exist, not a premature "found a window" against the splash/patch
+# dialog. Applies to both launch paths (direct and Steam) since both share
+# `_wait_for_gw_window`/`_wait_for_window_or_exit`.
+GW_MAIN_WINDOW_CLASS = "ArenaNet_Dx_Window_Class"
+
+
+def _is_gw_main_window(hwnd: int, pid: int) -> bool:
+    """True only for `pid`'s real 3D game window -- see `GW_MAIN_WINDOW_CLASS`'s
+    own comment for why class name, not just visibility+PID, is the right
+    filter here. Swallows `pywintypes.error` itself (returns False) rather
+    than letting callers each repeat the same "a window can be destroyed
+    mid-enumeration" guard.
+    """
+    try:
+        if not win32gui.IsWindowVisible(hwnd):
+            return False
+        _, window_pid = win32process.GetWindowThreadProcessId(hwnd)
+        if window_pid != pid:
+            return False
+        return win32gui.GetClassName(hwnd) == GW_MAIN_WINDOW_CLASS
+    except pywintypes.error:
+        return False
+
 VIRTUAL_MEM = 0x1000 | 0x2000  # MEM_COMMIT | MEM_RESERVE
 PAGE_READWRITE = 0x04
 MEM_RELEASE = 0x8000
@@ -508,15 +542,8 @@ def _wait_for_gw_window(pid: int, log: list, timeout: float = 30.0) -> bool:
     found_windows = []
 
     def enum_windows_callback(hwnd, _):
-        try:
-            if win32gui.IsWindowVisible(hwnd):
-                _, window_pid = win32process.GetWindowThreadProcessId(hwnd)
-                if window_pid == pid:
-                    found_windows.append(hwnd)
-        except pywintypes.error:
-            # A window can be destroyed mid-enumeration; skip it rather than letting
-            # one bad handle crash the whole enumeration (see window_control.py).
-            pass
+        if _is_gw_main_window(hwnd, pid):
+            found_windows.append(hwnd)
         return True
 
     while time.time() - start_time < timeout:
@@ -546,18 +573,32 @@ def _wait_for_window_or_exit(
     absolute_ceiling: float = ABSOLUTE_CEILING_DEFAULT,
     hang_fail_threshold: float = HANG_FAIL_THRESHOLD_DEFAULT,
 ) -> str:
-    """Poll `pid` for whichever happens first: a visible, *responsive* window while
-    still alive (the normal case -- return "window"), or the process exiting before
-    any window appears (the updater/relaunch handoff case -- return "exited").
+    """Poll `pid` for whichever happens first: a visible, *responsive*
+    `GW_MAIN_WINDOW_CLASS` window while still alive (the normal case --
+    return "window"), or the process exiting before that window appears
+    (the updater/relaunch handoff case -- return "exited").
 
-    Stall-based, not elapsed-time-based: a window that exists but reports hung
-    (``IsHungAppWindow``) is treated as "still legitimately busy" -- e.g. GW showing
-    a not-responding window while it unpacks a large update -- and polling continues.
-    Only two things actually fail this wait: (a) the process exits with no window
-    ever appearing, or (b) a window stays hung for `hang_fail_threshold` seconds
-    straight, which is treated as an actual freeze/crash rather than a slow update.
-    `absolute_ceiling` is a last-resort safety valve for the case where neither of
-    those clean signals ever fires, not a tuned duration -- see its docstring.
+    Class-filtered, not "any window for this PID" -- see
+    `GW_MAIN_WINDOW_CLASS`'s own comment. The splash/patch dialog
+    (`ArenaNet_Dialog_Class`) staying up for however long a real content
+    update takes is exactly why this matters: this function simply doesn't
+    count it as a match at all, rather than accepting it early and reporting
+    "window" before the game is actually ready. A slow patch just reads as
+    "still polling, nothing found yet" here -- `absolute_ceiling` (not
+    `hang_fail_threshold`) is what actually bounds that wait now.
+
+    Still stall-based on top of that class filter, not elapsed-time-based,
+    for the main window itself once it exists: a `GW_MAIN_WINDOW_CLASS`
+    window that reports hung (``IsHungAppWindow``) is treated as "still
+    legitimately busy" -- e.g. a large in-place data redownload after the
+    real window already appeared (see this module's own docstring for that
+    variant) -- and polling continues. Only two things actually fail this
+    wait: (a) the process exits with no matching window ever appearing, or
+    (b) a `GW_MAIN_WINDOW_CLASS` window stays hung for `hang_fail_threshold`
+    seconds straight, treated as an actual freeze/crash rather than a slow
+    update. `absolute_ceiling` is a last-resort safety valve for the case
+    where neither of those clean signals ever fires, not a tuned duration --
+    see its docstring.
 
     This also has to be a single combined poll, not a sequential "wait for exit,
     then wait for a window": sequencing them means the normal (no update pending)
@@ -574,15 +615,8 @@ def _wait_for_window_or_exit(
     found_windows = []
 
     def enum_windows_callback(hwnd, _):
-        try:
-            if win32gui.IsWindowVisible(hwnd):
-                _, window_pid = win32process.GetWindowThreadProcessId(hwnd)
-                if window_pid == pid:
-                    found_windows.append(hwnd)
-        except pywintypes.error:
-            # A window can be destroyed mid-enumeration; skip it rather than letting
-            # one bad handle crash the whole enumeration (see window_control.py).
-            pass
+        if _is_gw_main_window(hwnd, pid):
+            found_windows.append(hwnd)
         return True
 
     while time.time() - start_time < absolute_ceiling:
@@ -919,7 +953,8 @@ def _redact_command_line_for_log(command_line: str) -> str:
 def _launch_gw1_via_steam(
     profile: GameProfile,
     *,
-    window_wait_timeout: float,
+    absolute_ceiling: float,
+    hang_fail_threshold: float,
     post_window_settle_delay: float,
     multiclient_enabled: bool,
     py4gw_injection_enabled: bool,
@@ -972,6 +1007,16 @@ def _launch_gw1_via_steam(
     doesn't apply here -- name-plus-recency is already unambiguous for a
     Steam-owned launch, so there's nothing this validation actually buys on
     this path, only a way for a stale field to silently break it.
+
+    Uses `_wait_for_window_or_exit` (`absolute_ceiling`/`hang_fail_threshold`),
+    not a flat `window_wait_timeout` -- found live, same failure shape as
+    the attach-timeout bug above: a genuine content update after a Steam
+    launch can take minutes, and this now specifically waits for
+    `GW_MAIN_WINDOW_CLASS` (see that constant's own comment), not just any
+    window, so the splash/patch dialog staying up doesn't get mistaken for
+    "ready." Chris's own point, and correct: this is the same shape of
+    problem the direct-launch path already handles for exactly this reason
+    -- unified onto the same function rather than re-solving it here.
     """
     _apply_gw1_registry_fix(profile, log)
 
@@ -1012,8 +1057,14 @@ def _launch_gw1_via_steam(
     else:
         _log(log, "gMod injection disabled for this profile -- launching without it")
 
-    if not _wait_for_gw_window(pid, log, timeout=window_wait_timeout):
-        return LaunchResult(False, pid, "GW window never appeared", log)
+    outcome = _wait_for_window_or_exit(pid, log, absolute_ceiling=absolute_ceiling, hang_fail_threshold=hang_fail_threshold)
+    if outcome == "exited":
+        return LaunchResult(False, pid, "Gw.exe exited before its main window ever appeared", log)
+    elif outcome == "hung":
+        return LaunchResult(False, pid, f"Window stayed hung for {hang_fail_threshold}s+; treating as stuck, not a slow update", log)
+    elif outcome == "timeout":
+        return LaunchResult(False, pid, f"Hit the absolute ceiling ({absolute_ceiling}s) with no window, exit, or hang signal", log)
+    # outcome == "window": pid's window is already confirmed, fall straight through.
 
     if profile.auto_select_character_enabled and profile.character_name:
         window_title = profile.character_name
@@ -1128,7 +1179,8 @@ def launch_py4gw_profile(
     if profile.use_steam_login:
         return _launch_gw1_via_steam(
             profile,
-            window_wait_timeout=window_wait_timeout,
+            absolute_ceiling=absolute_ceiling,
+            hang_fail_threshold=hang_fail_threshold,
             post_window_settle_delay=post_window_settle_delay,
             multiclient_enabled=multiclient_enabled,
             py4gw_injection_enabled=py4gw_injection_enabled,

--- a/Py4GW_Reforged_Launcher/launcher_core/profile.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/profile.py
@@ -66,6 +66,18 @@ class GameProfile:
     auto_select_character_enabled: bool = False
     character_name: str = ""
 
+    # RELAY 094: Steam-linked accounts have no email Py4GW can read from
+    # memory (Apo confirmed directly -- no suitable replacement exists), so
+    # email/password_protected/auto_select_character_enabled/character_name
+    # are all meaningless when this is on and get hidden in the UI.
+    # steam_account_anchor is an opaque user-chosen string (not an email),
+    # written into Py4GW.ini's [settings] account_anchor key (a distinct
+    # key from autoexec_script's email-based settings-folder resolution) --
+    # only needed if a profile's widgets/scripts depend on the per-account
+    # settings folder existing.
+    use_steam_login: bool = False
+    steam_account_anchor: str = ""
+
     # -----------------------------
     # Window placement
     # -----------------------------

--- a/Py4GW_Reforged_Launcher/launcher_core/settings_store.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/settings_store.py
@@ -289,3 +289,23 @@ def load_custom_palette(path: Path | str | None = None) -> Optional[dict]:
 def save_custom_palette(custom_palette: dict, path: Path | str | None = None) -> None:
     resolved = Path(path) if path is not None else default_settings_path()
     _save_one("custom_palette", dict(custom_palette), resolved)
+
+
+def load_window_geometry(path: Path | str | None = None) -> Optional[dict]:
+    """RELAY 095: None means "nothing saved yet" -- run_shell.main() falls
+    back to its own hardcoded first-run default (width=601, height=817, no
+    x/y, not maximized), same "None means use the default, caller resolves
+    it" shape as load_mod_repo_path/load_custom_palette above. Stores
+    logical px (pywebview's own create_window unit), restored-state size
+    (not the maximized size -- see run_shell.py's own resize/move handlers
+    for why those are skipped while maximized) plus a separate maximized
+    flag."""
+    resolved = Path(path) if path is not None else default_settings_path()
+    data = _load_all(resolved)
+    value = data.get("window_geometry")
+    return dict(value) if value else None
+
+
+def save_window_geometry(window_geometry: dict, path: Path | str | None = None) -> None:
+    resolved = Path(path) if path is not None else default_settings_path()
+    _save_one("window_geometry", dict(window_geometry), resolved)

--- a/Py4GW_Reforged_Launcher/launcher_core/test_accounts_store.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/test_accounts_store.py
@@ -295,6 +295,40 @@ class TestDuplicateDedup(unittest.TestCase):
         self.assertEqual(sorted(profiles[0].team_ids), ["Class Team", "Misc Team"])
         self.assertEqual(sorted(t.name for t in teams), ["Class Team", "Misc Team"])
 
+    def test_two_distinct_blank_path_profiles_are_not_collapsed(self):
+        """RELAY 094 follow-up: a Steam-login profile (no use for
+        executable_path anymore) sharing a blank path AND blank
+        character_name with any other placeholder/blank profile used to
+        merge into one via the unconditional exe_char key -- found live,
+        a real profile silently vanished this way. Two genuinely distinct
+        accounts, both blank on path and character_name, must stay separate
+        profiles across a save/reload round trip."""
+        steam_profile = {
+            "id": "steam-id-1",
+            "name": "Steam",
+            "gw_path": "",
+            "character_name": "",
+            "use_steam_login": True,
+        }
+        unnamed_profile = {
+            "id": "unnamed-id-2",
+            "name": "",
+            "gw_path": "",
+            "character_name": "",
+        }
+        data = {accounts_store._UNASSIGNED_TEAM_KEY: [steam_profile, unnamed_profile]}
+        self.path.write_text(json.dumps(data), encoding="utf-8")
+
+        profiles = accounts_store.load_profiles(self.path)
+        self.assertEqual(len(profiles), 2)
+        self.assertEqual({p.id for p in profiles}, {"steam-id-1", "unnamed-id-2"})
+
+        # And a save/reload round trip must not collapse them either.
+        accounts_store.save_profiles(profiles, self.path)
+        reloaded = accounts_store.load_profiles(self.path)
+        self.assertEqual(len(reloaded), 2)
+        self.assertEqual({p.id for p in reloaded}, {"steam-id-1", "unnamed-id-2"})
+
     def test_inconsistent_email_across_listings_still_merges(self):
         # RELAY 061's own real gap -- one listing has email, the other blank.
         with_email = {

--- a/Py4GW_Reforged_Launcher/launcher_core/test_accounts_store.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/test_accounts_store.py
@@ -117,6 +117,27 @@ class TestBasicRoundTrip(unittest.TestCase):
         self.assertIn("id", tc1)
         self.assertIn("name", tc1)
 
+    def test_steam_login_fields_round_trip(self):
+        """RELAY 094: use_steam_login/steam_account_anchor are hand-listed
+        in _account_from_dict/_profile_to_dict same as every other new-
+        format field here -- GameProfile.py4gw_dll_path etc. above already
+        proved that pattern works; this is the same proof for these two.
+        Caught live: they were added to GameProfile (profile.py) and to
+        bridge.py's generic dataclasses.fields()-based save_profile, but
+        NOT to this hand-maintained pair, so a value set through the UI
+        silently vanished on the very next load -- exactly the failure a
+        round-trip test like the others in this class exists to catch."""
+        profiles = accounts_store.load_profiles(self.path)
+        p1 = next(p for p in profiles if p.character_name == "Test Char 1")
+        p1.use_steam_login = True
+        p1.steam_account_anchor = "some-anchor"
+        accounts_store.save_profiles(profiles, self.path)
+
+        reloaded = accounts_store.load_profiles(self.path)
+        r1 = next(p for p in reloaded if p.character_name == "Test Char 1")
+        self.assertTrue(r1.use_steam_login)
+        self.assertEqual(r1.steam_account_anchor, "some-anchor")
+
     def test_ids_stable_across_reload(self):
         profiles = accounts_store.load_profiles(self.path)
         ids_before = {p.character_name: p.id for p in profiles}

--- a/Py4GW_Reforged_Launcher/launcher_core/test_gw1_launch.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/test_gw1_launch.py
@@ -25,6 +25,7 @@ Run: .venv\\Scripts\\python.exe -m unittest launcher_core.test_gw1_launch -v
 
 from __future__ import annotations
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -33,7 +34,10 @@ from unittest.mock import patch
 from launcher_core import gw1_launch
 from launcher_core.gw1_launch import (
     _attach_to_steam_process,
+    _is_gw_main_window,
     _resolve_gmod_launch_decision,
+    _wait_for_gw_window,
+    _wait_for_window_or_exit,
     _write_account_anchor,
     launch_py4gw_profile,
 )
@@ -123,6 +127,116 @@ class Py4GwHardFailRegressionTest(unittest.TestCase):
 
         self.assertFalse(result.success)
         self.assertIn("py4gw_dll_path not found", result.error or "")
+
+
+class GwMainWindowClassFilterTests(unittest.TestCase):
+    """RELAY 094 follow-up: found live (real GetClassName capture during an
+    actual launch, not assumed) that GW1 shows two genuinely distinct Win32
+    window classes at startup -- ArenaNet_Dialog_Class (the splash/patch
+    dialog) and ArenaNet_Dx_Window_Class (the real 3D game window),
+    confirmed as two separate hwnds for the same PID a fraction of a
+    second apart. Chris's own point: a real content update can keep the
+    dialog up for minutes, so injection timing must not treat "any window
+    for this PID" as "ready" -- _is_gw_main_window is the fix."""
+
+    def test_true_for_matching_class_and_pid(self):
+        with (
+            patch.object(gw1_launch.win32gui, "IsWindowVisible", return_value=True),
+            patch.object(gw1_launch.win32process, "GetWindowThreadProcessId", return_value=(0, 123)),
+            patch.object(gw1_launch.win32gui, "GetClassName", return_value=gw1_launch.GW_MAIN_WINDOW_CLASS),
+        ):
+            self.assertTrue(_is_gw_main_window(999, 123))
+
+    def test_false_for_splash_dialog_class(self):
+        with (
+            patch.object(gw1_launch.win32gui, "IsWindowVisible", return_value=True),
+            patch.object(gw1_launch.win32process, "GetWindowThreadProcessId", return_value=(0, 123)),
+            patch.object(gw1_launch.win32gui, "GetClassName", return_value="ArenaNet_Dialog_Class"),
+        ):
+            self.assertFalse(_is_gw_main_window(999, 123))
+
+    def test_false_for_wrong_pid(self):
+        with (
+            patch.object(gw1_launch.win32gui, "IsWindowVisible", return_value=True),
+            patch.object(gw1_launch.win32process, "GetWindowThreadProcessId", return_value=(0, 456)),
+            patch.object(gw1_launch.win32gui, "GetClassName", return_value=gw1_launch.GW_MAIN_WINDOW_CLASS),
+        ):
+            self.assertFalse(_is_gw_main_window(999, 123))
+
+    def test_false_for_invisible_window(self):
+        with patch.object(gw1_launch.win32gui, "IsWindowVisible", return_value=False):
+            self.assertFalse(_is_gw_main_window(999, 123))
+
+    def test_false_not_raises_on_pywintypes_error(self):
+        """A window can be destroyed mid-enumeration -- must not raise."""
+        with patch.object(gw1_launch.win32gui, "IsWindowVisible", side_effect=gw1_launch.pywintypes.error("boom")):
+            self.assertFalse(_is_gw_main_window(999, 123))
+
+
+class WaitFunctionsIgnoreSplashDialogTests(unittest.TestCase):
+    """Confirms _wait_for_gw_window/_wait_for_window_or_exit actually use
+    the class filter end to end (not just that _is_gw_main_window is
+    correct in isolation) -- reproduces the exact live scenario: a real
+    ArenaNet_Dialog_Class window appearing before ArenaNet_Dx_Window_Class."""
+
+    @staticmethod
+    def _fake_enum_windows(hwnd_classes):
+        def fake_enum_windows(callback, extra):
+            for hwnd in hwnd_classes:
+                callback(hwnd, extra)
+        return fake_enum_windows
+
+    def test_wait_for_gw_window_ignores_dialog_finds_dx_window(self):
+        pid = os.getpid()  # a real, running process -- psutil's status check needs one
+        hwnd_classes = {111: "ArenaNet_Dialog_Class", 222: gw1_launch.GW_MAIN_WINDOW_CLASS}
+        with (
+            patch.object(gw1_launch.win32gui, "EnumWindows", side_effect=self._fake_enum_windows(hwnd_classes)),
+            patch.object(gw1_launch.win32gui, "IsWindowVisible", return_value=True),
+            patch.object(gw1_launch.win32process, "GetWindowThreadProcessId", return_value=(0, pid)),
+            patch.object(gw1_launch.win32gui, "GetClassName", side_effect=lambda h: hwnd_classes[h]),
+        ):
+            self.assertTrue(_wait_for_gw_window(pid, log=[], timeout=1.0))
+
+    def test_wait_for_gw_window_times_out_if_only_dialog_ever_appears(self):
+        pid = os.getpid()
+        hwnd_classes = {111: "ArenaNet_Dialog_Class"}
+        with (
+            patch.object(gw1_launch.win32gui, "EnumWindows", side_effect=self._fake_enum_windows(hwnd_classes)),
+            patch.object(gw1_launch.win32gui, "IsWindowVisible", return_value=True),
+            patch.object(gw1_launch.win32process, "GetWindowThreadProcessId", return_value=(0, pid)),
+            patch.object(gw1_launch.win32gui, "GetClassName", side_effect=lambda h: hwnd_classes[h]),
+        ):
+            self.assertFalse(_wait_for_gw_window(pid, log=[], timeout=0.3))
+
+    def test_wait_for_window_or_exit_ignores_dialog_returns_window_for_dx_class(self):
+        pid = os.getpid()
+        hwnd_classes = {111: "ArenaNet_Dialog_Class", 222: gw1_launch.GW_MAIN_WINDOW_CLASS}
+        with (
+            patch.object(gw1_launch.win32gui, "EnumWindows", side_effect=self._fake_enum_windows(hwnd_classes)),
+            patch.object(gw1_launch.win32gui, "IsWindowVisible", return_value=True),
+            patch.object(gw1_launch.win32process, "GetWindowThreadProcessId", return_value=(0, pid)),
+            patch.object(gw1_launch.win32gui, "GetClassName", side_effect=lambda h: hwnd_classes[h]),
+            patch.object(gw1_launch.user32, "IsHungAppWindow", return_value=False),
+        ):
+            outcome = _wait_for_window_or_exit(pid, log=[], absolute_ceiling=1.0, hang_fail_threshold=60.0)
+        self.assertEqual(outcome, "window")
+
+    def test_wait_for_window_or_exit_only_dialog_present_hits_ceiling_not_hang(self):
+        """The core fix, proven end to end: a slow patch (dialog window
+        staying up, never reporting hung itself since it's a real,
+        responsive UI) must read as 'still waiting' bounded by
+        absolute_ceiling -- not mistaken for a hung main window, and not
+        accepted early as 'ready'."""
+        pid = os.getpid()
+        hwnd_classes = {111: "ArenaNet_Dialog_Class"}
+        with (
+            patch.object(gw1_launch.win32gui, "EnumWindows", side_effect=self._fake_enum_windows(hwnd_classes)),
+            patch.object(gw1_launch.win32gui, "IsWindowVisible", return_value=True),
+            patch.object(gw1_launch.win32process, "GetWindowThreadProcessId", return_value=(0, pid)),
+            patch.object(gw1_launch.win32gui, "GetClassName", side_effect=lambda h: hwnd_classes[h]),
+        ):
+            outcome = _wait_for_window_or_exit(pid, log=[], absolute_ceiling=0.3, hang_fail_threshold=60.0)
+        self.assertEqual(outcome, "timeout")
 
 
 class SteamLoginBypassesExecutablePathGateTests(unittest.TestCase):

--- a/Py4GW_Reforged_Launcher/launcher_core/test_gw1_launch.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/test_gw1_launch.py
@@ -125,6 +125,51 @@ class Py4GwHardFailRegressionTest(unittest.TestCase):
         self.assertIn("py4gw_dll_path not found", result.error or "")
 
 
+class SteamLoginBypassesExecutablePathGateTests(unittest.TestCase):
+    """RELAY 094 follow-up, found via a real live test: a Steam profile with
+    no (or a stale/wrong) executable_path used to either hard-fail at
+    launch_py4gw_profile's top gate, or -- worse -- silently reject every
+    real attach match once the direct-launch path check moved into
+    _launch_gw1_via_steam, because a profile that had ever been pointed at
+    steam.exe (the old pre-toggle habit) can never path-match the real
+    discovered Gw.exe. Confirmed live: character-select screen reached,
+    zero injection attempted, console showed repeated attach timeouts."""
+
+    def test_empty_executable_path_does_not_hard_fail_a_steam_profile(self):
+        profile = GameProfile(use_steam_login=True, executable_path="")
+        with patch.object(gw1_launch, "_launch_gw1_via_steam") as mock_steam_launch:
+            mock_steam_launch.return_value = gw1_launch.LaunchResult(True, 123, None, [])
+            result = launch_py4gw_profile(profile)
+        self.assertTrue(result.success)
+        mock_steam_launch.assert_called_once()
+
+    def test_attach_ignores_profile_executable_path_even_when_wrong(self):
+        """The exact failure mode hit live: executable_path left pointing at
+        steam.exe (or anything else) must not stop a real Gw.exe from being
+        accepted -- Apo's own confirmation that a user can only have one
+        Steam-linked account is what makes dropping this check safe."""
+        profile = GameProfile(
+            use_steam_login=True,
+            executable_path="C:/Program Files (x86)/Steam/steam.exe",  # deliberately wrong/stale
+        )
+        with (
+            patch.object(gw1_launch.os, "startfile"),
+            patch.object(gw1_launch, "_attach_to_steam_process", return_value=None) as mock_attach,
+        ):
+            launch_py4gw_profile(profile)
+        mock_attach.assert_called_once()
+        called_exe_path = mock_attach.call_args[0][0]
+        self.assertEqual(called_exe_path, "")  # not profile.executable_path
+
+    def test_steam_attach_timeout_default_bumped_past_gwxlauncher_parity(self):
+        """GWxLauncher's own reference default is 5s -- found live that a
+        cold Steam launch can legitimately take longer than that just to
+        spawn Gw.exe as a process, well before any window ever appears."""
+        import inspect
+        sig = inspect.signature(launch_py4gw_profile)
+        self.assertGreater(sig.parameters["steam_attach_timeout"].default, 5.0)
+
+
 class WriteAccountAnchorTests(unittest.TestCase):
     """RELAY 094: _write_account_anchor mirrors _write_autoexec_script's own
     read-modify-write shape exactly (RELAY 057) -- these tests are the same

--- a/Py4GW_Reforged_Launcher/launcher_core/test_gw1_launch.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/test_gw1_launch.py
@@ -12,6 +12,14 @@ py4gw_dll_path hard-fail (deliberately unchanged by this entry) still fires
 before any process gets created -- that path doesn't touch Win32 either,
 since it returns before CreateProcessW.
 
+RELAY 094 adds two more testable-without-Win32 pieces: _write_account_anchor
+(same plain-configparser read-modify-write shape as _write_autoexec_script,
+just a different ini key) and _attach_to_steam_process's process-name-match-
+plus-path-validation logic (mocks psutil.process_iter directly rather than
+touching real OS processes -- the actual OpenProcess/ReadProcessMemory/
+CreateRemoteThread injection surface stays untested here, same boundary
+the rest of this file already draws).
+
 Run: .venv\\Scripts\\python.exe -m unittest launcher_core.test_gw1_launch -v
 """
 
@@ -23,7 +31,12 @@ from pathlib import Path
 from unittest.mock import patch
 
 from launcher_core import gw1_launch
-from launcher_core.gw1_launch import _resolve_gmod_launch_decision, launch_py4gw_profile
+from launcher_core.gw1_launch import (
+    _attach_to_steam_process,
+    _resolve_gmod_launch_decision,
+    _write_account_anchor,
+    launch_py4gw_profile,
+)
 from launcher_core.profile import GameProfile
 
 
@@ -110,6 +123,124 @@ class Py4GwHardFailRegressionTest(unittest.TestCase):
 
         self.assertFalse(result.success)
         self.assertIn("py4gw_dll_path not found", result.error or "")
+
+
+class WriteAccountAnchorTests(unittest.TestCase):
+    """RELAY 094: _write_account_anchor mirrors _write_autoexec_script's own
+    read-modify-write shape exactly (RELAY 057) -- these tests are the same
+    shape as that function would need, just none existed for either before
+    this entry (verified via a real search, same situation this file's own
+    module docstring already flags)."""
+
+    def setUp(self):
+        self.log: list = []
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.mod_root_path = Path(self._tmpdir.name)
+        self._patcher = patch.object(gw1_launch, "_mod_root", return_value=self.mod_root_path)
+        self._patcher.start()
+        self.addCleanup(self._patcher.stop)
+
+    def test_writes_key_into_new_ini(self):
+        _write_account_anchor("my-anchor", self.log)
+        ini_path = self.mod_root_path / "Py4GW.ini"
+        self.assertTrue(ini_path.exists())
+        content = ini_path.read_text()
+        self.assertIn("account_anchor = my-anchor", content)
+        self.assertTrue(any("Wrote account_anchor" in line for line in self.log))
+
+    def test_preserves_other_keys_and_sections(self):
+        ini_path = self.mod_root_path / "Py4GW.ini"
+        ini_path.write_text("[settings]\nautoexec_script = C:/some/script.py\n\n[other]\nkey = value\n")
+
+        _write_account_anchor("my-anchor", self.log)
+
+        content = ini_path.read_text()
+        self.assertIn("autoexec_script = C:/some/script.py", content)
+        self.assertIn("account_anchor = my-anchor", content)
+        self.assertIn("[other]", content)
+        self.assertIn("key = value", content)
+
+    def test_overwrites_stale_value_for_same_key(self):
+        ini_path = self.mod_root_path / "Py4GW.ini"
+        ini_path.write_text("[settings]\naccount_anchor = old-anchor\n")
+
+        _write_account_anchor("new-anchor", self.log)
+
+        content = ini_path.read_text()
+        self.assertIn("account_anchor = new-anchor", content)
+        self.assertNotIn("old-anchor", content)
+
+    def test_write_failure_is_non_fatal(self):
+        with patch("builtins.open", side_effect=OSError("disk full")):
+            _write_account_anchor("my-anchor", self.log)  # must not raise
+        self.assertTrue(any("non-fatal" in line for line in self.log))
+
+
+class AttachToSteamProcessTests(unittest.TestCase):
+    """RELAY 094: _attach_to_steam_process's name-match-plus-path-validation
+    logic, ported from GWxLauncher's SteamProcessAttachService.TryAttachToSteamProcess
+    with one addition that reference doesn't have (see the function's own
+    docstring) -- mocks psutil.process_iter directly, no real processes or
+    Win32 calls involved."""
+
+    class _FakeProc:
+        def __init__(self, info: dict):
+            self.info = info
+
+    def _iter(self, procs):
+        return lambda attrs: iter(procs)
+
+    def test_finds_matching_process_by_name_and_path(self):
+        proc = self._FakeProc({"pid": 4242, "name": "Gw.exe", "exe": "C:/Games/GW/Gw.exe", "create_time": 1000.0})
+        with patch.object(gw1_launch.psutil, "process_iter", side_effect=self._iter([proc])):
+            pid = _attach_to_steam_process("C:/Games/GW/Gw.exe", launched_after=999.0, log=[], timeout=1.0)
+        self.assertEqual(pid, 4242)
+
+    def test_rejects_process_with_mismatched_exe_path(self):
+        """The addition GWxLauncher's own reference doesn't have: name-only
+        matching isn't enough in a multibox tool where more than one Gw.exe
+        copy across different accounts is the normal case."""
+        wrong_path_proc = self._FakeProc(
+            {"pid": 111, "name": "Gw.exe", "exe": "C:/Other/Account/Gw.exe", "create_time": 1000.0}
+        )
+        with patch.object(gw1_launch.psutil, "process_iter", side_effect=self._iter([wrong_path_proc])):
+            pid = _attach_to_steam_process("C:/Games/GW/Gw.exe", launched_after=999.0, log=[], timeout=0.05)
+        self.assertIsNone(pid)
+
+    def test_rejects_process_created_before_launch_timestamp(self):
+        """A leftover Gw.exe from an earlier session must not be mistaken
+        for the one Steam just spawned."""
+        stale_proc = self._FakeProc(
+            {"pid": 222, "name": "Gw.exe", "exe": "C:/Games/GW/Gw.exe", "create_time": 500.0}
+        )
+        with patch.object(gw1_launch.psutil, "process_iter", side_effect=self._iter([stale_proc])):
+            pid = _attach_to_steam_process("C:/Games/GW/Gw.exe", launched_after=999.0, log=[], timeout=0.05)
+        self.assertIsNone(pid)
+
+    def test_empty_exe_path_skips_path_check(self):
+        """profile.executable_path being unresolvable/empty shouldn't reject
+        an otherwise-good name+recency match -- name-plus-recency is still
+        meaningfully selective on its own (see the function's own docstring)."""
+        proc = self._FakeProc({"pid": 333, "name": "Gw.exe", "exe": "C:/Anything/Gw.exe", "create_time": 1000.0})
+        with patch.object(gw1_launch.psutil, "process_iter", side_effect=self._iter([proc])):
+            pid = _attach_to_steam_process("", launched_after=999.0, log=[], timeout=1.0)
+        self.assertEqual(pid, 333)
+
+    def test_ignores_unrelated_process_names(self):
+        unrelated = self._FakeProc(
+            {"pid": 444, "name": "notepad.exe", "exe": "C:/Windows/notepad.exe", "create_time": 1000.0}
+        )
+        with patch.object(gw1_launch.psutil, "process_iter", side_effect=self._iter([unrelated])):
+            pid = _attach_to_steam_process("C:/Games/GW/Gw.exe", launched_after=999.0, log=[], timeout=0.05)
+        self.assertIsNone(pid)
+
+    def test_timeout_returns_none_and_logs(self):
+        log: list = []
+        with patch.object(gw1_launch.psutil, "process_iter", side_effect=self._iter([])):
+            pid = _attach_to_steam_process("C:/Games/GW/Gw.exe", launched_after=999.0, log=log, timeout=0.05)
+        self.assertIsNone(pid)
+        self.assertTrue(any("Timed out" in line for line in log))
 
 
 if __name__ == "__main__":

--- a/Py4GW_Reforged_Launcher/launcher_core/test_gw1_launch.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/test_gw1_launch.py
@@ -36,7 +36,6 @@ from launcher_core.gw1_launch import (
     _attach_to_steam_process,
     _is_gw_main_window,
     _resolve_gmod_launch_decision,
-    _wait_for_gw_window,
     _wait_for_window_or_exit,
     _write_account_anchor,
     launch_py4gw_profile,
@@ -174,10 +173,10 @@ class GwMainWindowClassFilterTests(unittest.TestCase):
 
 
 class WaitFunctionsIgnoreSplashDialogTests(unittest.TestCase):
-    """Confirms _wait_for_gw_window/_wait_for_window_or_exit actually use
-    the class filter end to end (not just that _is_gw_main_window is
-    correct in isolation) -- reproduces the exact live scenario: a real
-    ArenaNet_Dialog_Class window appearing before ArenaNet_Dx_Window_Class."""
+    """Confirms _wait_for_window_or_exit actually uses the class filter end
+    to end (not just that _is_gw_main_window is correct in isolation) --
+    reproduces the exact live scenario: a real ArenaNet_Dialog_Class window
+    appearing before ArenaNet_Dx_Window_Class."""
 
     @staticmethod
     def _fake_enum_windows(hwnd_classes):
@@ -185,28 +184,6 @@ class WaitFunctionsIgnoreSplashDialogTests(unittest.TestCase):
             for hwnd in hwnd_classes:
                 callback(hwnd, extra)
         return fake_enum_windows
-
-    def test_wait_for_gw_window_ignores_dialog_finds_dx_window(self):
-        pid = os.getpid()  # a real, running process -- psutil's status check needs one
-        hwnd_classes = {111: "ArenaNet_Dialog_Class", 222: gw1_launch.GW_MAIN_WINDOW_CLASS}
-        with (
-            patch.object(gw1_launch.win32gui, "EnumWindows", side_effect=self._fake_enum_windows(hwnd_classes)),
-            patch.object(gw1_launch.win32gui, "IsWindowVisible", return_value=True),
-            patch.object(gw1_launch.win32process, "GetWindowThreadProcessId", return_value=(0, pid)),
-            patch.object(gw1_launch.win32gui, "GetClassName", side_effect=lambda h: hwnd_classes[h]),
-        ):
-            self.assertTrue(_wait_for_gw_window(pid, log=[], timeout=1.0))
-
-    def test_wait_for_gw_window_times_out_if_only_dialog_ever_appears(self):
-        pid = os.getpid()
-        hwnd_classes = {111: "ArenaNet_Dialog_Class"}
-        with (
-            patch.object(gw1_launch.win32gui, "EnumWindows", side_effect=self._fake_enum_windows(hwnd_classes)),
-            patch.object(gw1_launch.win32gui, "IsWindowVisible", return_value=True),
-            patch.object(gw1_launch.win32process, "GetWindowThreadProcessId", return_value=(0, pid)),
-            patch.object(gw1_launch.win32gui, "GetClassName", side_effect=lambda h: hwnd_classes[h]),
-        ):
-            self.assertFalse(_wait_for_gw_window(pid, log=[], timeout=0.3))
 
     def test_wait_for_window_or_exit_ignores_dialog_returns_window_for_dx_class(self):
         pid = os.getpid()
@@ -237,6 +214,60 @@ class WaitFunctionsIgnoreSplashDialogTests(unittest.TestCase):
         ):
             outcome = _wait_for_window_or_exit(pid, log=[], absolute_ceiling=0.3, hang_fail_threshold=60.0)
         self.assertEqual(outcome, "timeout")
+
+
+class RespawnRetryLoopTests(unittest.TestCase):
+    """RELAY 094 follow-up: Chris's own live-play observation -- a patch
+    cycle can involve the process itself exiting and respawning more than
+    once (his own words: "1-2 maybe 3 splash window transitions"), not
+    just the single Gw.tmp-style handoff this pipeline originally only
+    tolerated once. Tests the Steam path's retry loop directly (mocking
+    _wait_for_window_or_exit/_attach_to_steam_process) -- the direct
+    path's loop shares the identical shape but pulls in CreateProcessW and
+    the rest of the suspended-launch pipeline, outside this file's
+    existing Win32-mocking boundary (see this module's own docstring)."""
+
+    @staticmethod
+    def _steam_profile():
+        return GameProfile(use_steam_login=True, executable_path="")
+
+    def test_retries_through_multiple_exits_then_succeeds(self):
+        wait_outcomes = iter(["exited", "exited", "window"])
+        with (
+            patch.object(gw1_launch.os, "startfile"),
+            patch.object(gw1_launch, "_attach_to_steam_process", side_effect=[111, 222, 333]),
+            patch.object(gw1_launch, "_wait_for_window_or_exit", side_effect=lambda *a, **k: next(wait_outcomes)),
+            patch.object(gw1_launch, "_apply_multiclient_patch", return_value=True),
+        ):
+            result = launch_py4gw_profile(self._steam_profile(), py4gw_injection_enabled=False)
+        self.assertTrue(result.success)
+        self.assertEqual(result.pid, 333)  # the second respawn's pid, not the original
+
+    def test_gives_up_after_exhausting_max_respawn_attempts(self):
+        with (
+            patch.object(gw1_launch.os, "startfile"),
+            patch.object(gw1_launch, "_attach_to_steam_process", return_value=999),
+            patch.object(gw1_launch, "_wait_for_window_or_exit", return_value="exited") as mock_wait,
+            patch.object(gw1_launch, "_apply_multiclient_patch", return_value=True),
+        ):
+            result = launch_py4gw_profile(self._steam_profile(), py4gw_injection_enabled=False)
+        self.assertFalse(result.success)
+        self.assertIn("kept exiting", result.error)
+        # initial wait + MAX_PROCESS_RESPAWN_ATTEMPTS retries, never more
+        self.assertEqual(mock_wait.call_count, gw1_launch.MAX_PROCESS_RESPAWN_ATTEMPTS + 1)
+
+    def test_stops_retrying_if_rediscovery_itself_fails(self):
+        with (
+            patch.object(gw1_launch.os, "startfile"),
+            patch.object(gw1_launch, "_attach_to_steam_process", side_effect=[111, None]),
+            patch.object(gw1_launch, "_wait_for_window_or_exit", return_value="exited") as mock_wait,
+            patch.object(gw1_launch, "_apply_multiclient_patch", return_value=True),
+        ):
+            result = launch_py4gw_profile(self._steam_profile(), py4gw_injection_enabled=False)
+        self.assertFalse(result.success)
+        self.assertIn("kept exiting", result.error)
+        # gave up right after rediscovery failed, not after exhausting every attempt
+        self.assertEqual(mock_wait.call_count, 1)
 
 
 class SteamLoginBypassesExecutablePathGateTests(unittest.TestCase):

--- a/Py4GW_Reforged_Launcher/launcher_core/test_settings_store.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/test_settings_store.py
@@ -1,0 +1,56 @@
+"""Unit tests for launcher_core/settings_store.py (RELAY 095).
+
+No committed test file existed for this module before now -- same "no test
+existed, wrote one" situation this repo has hit before. Only covers
+load_window_geometry/save_window_geometry (what this entry actually
+touched) -- not backfilling coverage for the module's other, pre-existing
+settings, which this entry didn't change.
+
+Run: .venv\\Scripts\\python.exe -m unittest launcher_core.test_settings_store -v
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from launcher_core import settings_store
+
+
+class TestWindowGeometry(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmpdir.name) / "launcher_settings.json"
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_none_when_nothing_saved_yet(self):
+        """Caller (run_shell.main()) resolves its own hardcoded first-run
+        default from this -- same "None means use the default" shape as
+        load_mod_repo_path/load_custom_palette."""
+        self.assertIsNone(settings_store.load_window_geometry(self.path))
+
+    def test_round_trip(self):
+        geometry = {"x": 12, "y": 34, "width": 601, "height": 817, "maximized": False}
+        settings_store.save_window_geometry(geometry, self.path)
+        self.assertEqual(settings_store.load_window_geometry(self.path), geometry)
+
+    def test_save_preserves_other_settings_in_the_same_file(self):
+        """Real bug this module's own docstring exists to prevent -- a save
+        must merge into the existing file, not overwrite it wholesale."""
+        settings_store.save_bulk_launch_pacing_seconds(20, self.path)
+        settings_store.save_window_geometry({"x": 1, "y": 2, "width": 3, "height": 4, "maximized": True}, self.path)
+        self.assertEqual(settings_store.load_bulk_launch_pacing_seconds(self.path), 20)
+        self.assertEqual(settings_store.load_window_geometry(self.path)["maximized"], True)
+
+    def test_maximized_round_trips_as_a_real_bool(self):
+        settings_store.save_window_geometry(
+            {"x": 0, "y": 0, "width": 601, "height": 817, "maximized": True}, self.path
+        )
+        geometry = settings_store.load_window_geometry(self.path)
+        self.assertIs(geometry["maximized"], True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Py4GW_Reforged_Launcher/launcher_core/version.py
+++ b/Py4GW_Reforged_Launcher/launcher_core/version.py
@@ -5,4 +5,4 @@ Referenced by App Settings' version display and update-check
 release's tag exactly.
 """
 
-__version__ = "0.3.4-alpha"
+__version__ = "0.4.0-alpha"

--- a/Py4GW_Reforged_Launcher/pywebview_shell/run_shell.py
+++ b/Py4GW_Reforged_Launcher/pywebview_shell/run_shell.py
@@ -36,6 +36,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
+from typing import Optional
 
 import webview
 
@@ -88,6 +89,153 @@ RESIZE_MARGIN = 6
 #     the window edge. 320x300 landed on cleanly, matching every check in
 #     the entry: nothing overlapping, nothing missing, nothing unreachable.
 MIN_SIZE = (320, 300)
+
+
+# RELAY 095: debounced, same "quiet period before an autosave flush" idea the
+# native SettingsManager's own autosave pump already uses (settings-ini-
+# design.md) -- moved/resized fire on every pixel during a live drag/resize,
+# not something to write to disk on every single one of.
+_WINDOW_GEOMETRY_SAVE_DEBOUNCE_SECONDS = 0.5
+
+
+def clamp_window_geometry(
+    x: int,
+    y: int,
+    width: int,
+    height: int,
+    screens: list[tuple[int, int, int, int]],
+    min_size: tuple[int, int],
+) -> tuple[int, int, int, int]:
+    """Pure geometry (RELAY 095, same "no live window needed" spirit as
+    snap.py's own zone_rect/classify_zone split): clamp a saved (x, y,
+    width, height) against `screens` (each a (left, top, right, bottom)
+    rect, same coordinate space as x/y/width/height -- pywebview's logical
+    px) and `min_size`, so a saved position from a monitor that's since
+    been disconnected can never strand the window off-screen, and a saved
+    size below the window's own declared minimum is never applied.
+
+    Grows width/height up to min_size first. Then picks whichever screen
+    the saved rect overlaps the most (covers the common multi-monitor
+    case where the window was mostly on one screen); if it overlaps none
+    at all (the disconnected-monitor case), falls back to the first
+    screen instead of leaving the window unreachable. Finally shrinks
+    width/height to fit that screen if needed (a saved size from a larger
+    monitor applied to a smaller one) and nudges x/y so the whole window
+    -- not just some corner of it -- lands fully within that screen's
+    bounds.
+
+    Empty `screens` (couldn't query any -- shouldn't happen in practice,
+    but nothing here should ever hard-fail a window launch) is a no-op:
+    trust the (already min-size-clamped) input rather than guessing at a
+    fallback rect with no real data behind it.
+    """
+    min_w, min_h = min_size
+    width = max(width, min_w)
+    height = max(height, min_h)
+
+    if not screens:
+        return (x, y, width, height)
+
+    def _overlap_area(rect: tuple[int, int, int, int]) -> int:
+        left, top, right, bottom = rect
+        overlap_w = max(0, min(x + width, right) - max(x, left))
+        overlap_h = max(0, min(y + height, bottom) - max(y, top))
+        return overlap_w * overlap_h
+
+    best = max(screens, key=_overlap_area)
+    if _overlap_area(best) <= 0:
+        best = screens[0]
+
+    left, top, right, bottom = best
+    width = min(width, right - left)
+    height = min(height, bottom - top)
+    x = max(left, min(x, right - width))
+    y = max(top, min(y, bottom - height))
+    return (x, y, width, height)
+
+
+class _WindowGeometrySaver:
+    """RELAY 095: persists the launcher window's position/size/maximized
+    state across restarts, debounced (see
+    _WINDOW_GEOMETRY_SAVE_DEBOUNCE_SECONDS) via a Timer, flushed
+    immediately and synchronously on window close so an in-flight
+    debounce is never lost.
+
+    Deliberately ignores moved/resized while maximized -- confirmed
+    directly against webview's own winforms.py backend: a single on_resize
+    handler always calls events.resized.set(...) unconditionally, right
+    alongside the maximized/restored checks in that same handler, so
+    WinForms fires resized with the *maximized* dimensions on every
+    maximize too, not just genuine restored-state resizes. Saving blindly
+    would overwrite the remembered restored-state geometry with the
+    maximized one -- un-maximizing (or the next restart, if closed while
+    still maximized) would then have nothing sane to go back to. Only the
+    maximized flag itself updates while maximized; restored geometry is
+    left untouched until an actual restore happens.
+    """
+
+    def __init__(self) -> None:
+        self._x = 0
+        self._y = 0
+        self._width = 0
+        self._height = 0
+        self._maximized = False
+        self._timer: Optional[threading.Timer] = None
+        self._lock = threading.Lock()
+
+    def seed(self, x: int, y: int, width: int, height: int, maximized: bool) -> None:
+        """Initial known-good geometry -- the real, live values read back
+        from the window once shown (not just what was requested at
+        creation, which pywebview/the OS can adjust), so the first move/
+        resize event updates a true baseline instead of starting blank."""
+        self._x, self._y, self._width, self._height = x, y, width, height
+        self._maximized = maximized
+
+    def on_moved(self, x: int, y: int) -> None:
+        if self._maximized:
+            return
+        self._x, self._y = x, y
+        self._schedule_save()
+
+    def on_resized(self, width: int, height: int) -> None:
+        if self._maximized:
+            return
+        self._width, self._height = width, height
+        self._schedule_save()
+
+    def on_maximized(self) -> None:
+        self._maximized = True
+        self._schedule_save()
+
+    def on_restored(self) -> None:
+        self._maximized = False
+        self._schedule_save()
+
+    def _schedule_save(self) -> None:
+        with self._lock:
+            if self._timer is not None:
+                self._timer.cancel()
+            self._timer = threading.Timer(_WINDOW_GEOMETRY_SAVE_DEBOUNCE_SECONDS, self._save_now)
+            self._timer.daemon = True
+            self._timer.start()
+
+    def flush(self) -> None:
+        with self._lock:
+            if self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
+        self._save_now()
+
+    def _save_now(self) -> None:
+        settings_store.save_window_geometry(
+            {
+                "x": self._x,
+                "y": self._y,
+                "width": self._width,
+                "height": self._height,
+                "maximized": self._maximized,
+            }
+        )
 
 
 def _webview2_storage_path() -> str:
@@ -266,6 +414,29 @@ def main() -> None:
     bridge = ShellBridge("main")
     bridge.set_preview(preview)
     bridge.set_min_size(*MIN_SIZE)
+
+    # RELAY 095: remember the window's last position/size/maximized state.
+    # None saved yet (first run, or a pre-095 install) -- x/y stay None
+    # (create_window's own "let the OS decide" default, unchanged first-run
+    # behavior) and width/height stay the existing hardcoded defaults below.
+    saved_geometry = settings_store.load_window_geometry()
+    geometry_x: Optional[int] = None
+    geometry_y: Optional[int] = None
+    geometry_width = 601
+    geometry_height = 817
+    geometry_maximized = False
+    if saved_geometry:
+        screens = [(s.x, s.y, s.x + s.width, s.y + s.height) for s in webview.screens]
+        geometry_x, geometry_y, geometry_width, geometry_height = clamp_window_geometry(
+            int(saved_geometry.get("x", 0)),
+            int(saved_geometry.get("y", 0)),
+            int(saved_geometry.get("width", geometry_width)),
+            int(saved_geometry.get("height", geometry_height)),
+            screens,
+            MIN_SIZE,
+        )
+        geometry_maximized = bool(saved_geometry.get("maximized", False))
+
     window = webview.create_window(
         "Py4GW Reforged Launcher",
         url=str(WEB_DIR / "index.html"),
@@ -282,9 +453,13 @@ def main() -> None:
         # than requested (confirmed reproducibly: the old 1000x720 default
         # measured 984x681 in every screenshot this app has ever had taken
         # of it, a constant (16, 39) shortfall). Compensated for here so
-        # the ACTUAL window really is 585x778, not 569x739.
-        width=601,
-        height=817,
+        # the ACTUAL window really is 585x778, not 569x739. Overridden by
+        # saved geometry above once one exists.
+        width=geometry_width,
+        height=geometry_height,
+        x=geometry_x,
+        y=geometry_y,
+        maximized=geometry_maximized,
         min_size=MIN_SIZE,
         frameless=True,
         easy_drag=False,  # we move the window ourselves (bridge.drag_tick, wired
@@ -293,6 +468,19 @@ def main() -> None:
                           # WS_THICKFRAME border -- see bridge.on_drag_start.
     )
     bridge.bind_window(window)
+
+    # RELAY 095: hook geometry persistence right after the Window object
+    # exists -- events.moved/resized/maximized/restored/closing are plain
+    # Event objects on the instance, independent of the GUI thread's own
+    # lifecycle, so this doesn't need to wait for on_shown. Seeding with the
+    # real post-shown values (not just what was requested, which the OS can
+    # still adjust) happens inside on_shown below instead.
+    geometry_saver = _WindowGeometrySaver()
+    window.events.moved += geometry_saver.on_moved
+    window.events.resized += geometry_saver.on_resized
+    window.events.maximized += geometry_saver.on_maximized
+    window.events.restored += geometry_saver.on_restored
+    window.events.closing += lambda: geometry_saver.flush()
 
     # Seeded (not push_event'd -- see _record_console_line's own docstring)
     # before the page loads, so get_console_lines() picks it up on the
@@ -330,6 +518,14 @@ def main() -> None:
                 icon_path = Path(__file__).parent.parent / "assets" / "python_icon.ico"
                 window_control.set_window_icon(hwnd, str(icon_path))
             _start_render_watchdog(hwnd, bridge)
+        # RELAY 095: seed with the real, live post-shown geometry -- what
+        # actually got applied (pywebview/the OS can still adjust a
+        # requested x/y/width/height, e.g. clamping onto a work area of its
+        # own), not just what was requested above.
+        try:
+            geometry_saver.seed(window.x, window.y, window.width, window.height, geometry_maximized)
+        except Exception:
+            pass  # cosmetic persistence feature -- must never block startup
         preview.start()
 
     webview.start(on_shown, debug=False, storage_path=_webview2_storage_path())

--- a/Py4GW_Reforged_Launcher/pywebview_shell/test_run_shell.py
+++ b/Py4GW_Reforged_Launcher/pywebview_shell/test_run_shell.py
@@ -1,0 +1,82 @@
+"""Unit tests for pywebview_shell/run_shell.py's pure geometry (RELAY 095).
+
+No committed test file existed for run_shell.py before now -- same "no test
+existed, wrote one" situation this repo has hit before (088/091's own
+precedent). clamp_window_geometry() was deliberately pulled out as a pure
+function (same "no live window needed" split snap.py's zone_rect/
+classify_zone already established) specifically so it's testable in
+isolation from webview/Win32.
+
+Run: .venv\\Scripts\\python.exe -m unittest pywebview_shell.test_run_shell -v
+"""
+from __future__ import annotations
+
+import unittest
+
+from pywebview_shell.run_shell import MIN_SIZE, clamp_window_geometry
+
+
+class TestClampWindowGeometry(unittest.TestCase):
+    SCREEN = (0, 0, 2560, 1440)  # left, top, right, bottom
+
+    def test_geometry_fully_on_screen_is_unchanged(self):
+        result = clamp_window_geometry(100, 100, 601, 817, [self.SCREEN], MIN_SIZE)
+        self.assertEqual(result, (100, 100, 601, 817))
+
+    def test_width_and_height_grown_to_min_size(self):
+        x, y, w, h = clamp_window_geometry(100, 100, 50, 50, [self.SCREEN], MIN_SIZE)
+        self.assertEqual((w, h), MIN_SIZE)
+
+    def test_partially_off_right_edge_is_nudged_fully_onscreen(self):
+        # Window's right edge would land past the screen's right edge.
+        x, y, w, h = clamp_window_geometry(2500, 100, 601, 817, [self.SCREEN], MIN_SIZE)
+        self.assertEqual((w, h), (601, 817))  # size untouched, it still fits
+        self.assertEqual(x + w, self.SCREEN[2])  # nudged so the far edge lands exactly on-screen
+        self.assertGreaterEqual(x, self.SCREEN[0])
+
+    def test_partially_off_bottom_edge_is_nudged_fully_onscreen(self):
+        x, y, w, h = clamp_window_geometry(100, 1400, 601, 817, [self.SCREEN], MIN_SIZE)
+        self.assertEqual(y + h, self.SCREEN[3])
+        self.assertGreaterEqual(y, self.SCREEN[1])
+
+    def test_negative_position_is_nudged_onscreen(self):
+        x, y, w, h = clamp_window_geometry(-500, -500, 601, 817, [self.SCREEN], MIN_SIZE)
+        self.assertEqual(x, self.SCREEN[0])
+        self.assertEqual(y, self.SCREEN[1])
+
+    def test_disconnected_monitor_falls_back_to_first_screen(self):
+        """A saved position from a second monitor that's since been
+        unplugged must not strand the window somewhere unreachable --
+        the whole point of this entry."""
+        screens = [(0, 0, 1920, 1080)]
+        # Saved position was on a monitor to the right that no longer exists.
+        x, y, w, h = clamp_window_geometry(2500, 100, 601, 817, screens, MIN_SIZE)
+        left, top, right, bottom = screens[0]
+        self.assertGreaterEqual(x, left)
+        self.assertLessEqual(x + w, right)
+        self.assertGreaterEqual(y, top)
+        self.assertLessEqual(y + h, bottom)
+
+    def test_picks_the_screen_with_the_most_overlap(self):
+        """Multi-monitor: a window mostly on the second screen should clamp
+        against that screen, not silently snap back to the first one."""
+        screens = [(0, 0, 1920, 1080), (1920, 0, 3840, 1080)]
+        # Window sits almost entirely on the second screen, just 1px over the seam.
+        x, y, w, h = clamp_window_geometry(1919, 100, 601, 817, screens, MIN_SIZE)
+        self.assertGreaterEqual(x, 1920 - 1)  # stayed on/near the second screen, not yanked to screen 1
+
+    def test_window_bigger_than_screen_is_shrunk_to_fit(self):
+        screens = [(0, 0, 800, 600)]
+        x, y, w, h = clamp_window_geometry(0, 0, 1200, 900, screens, MIN_SIZE)
+        self.assertLessEqual(w, 800)
+        self.assertLessEqual(h, 600)
+
+    def test_empty_screens_list_is_a_no_op_beyond_min_size(self):
+        """Couldn't query any screens -- trust the input rather than
+        guessing at a fallback rect with no real data behind it."""
+        result = clamp_window_geometry(100, 100, 601, 817, [], MIN_SIZE)
+        self.assertEqual(result, (100, 100, 601, 817))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Py4GW_Reforged_Launcher/pywebview_shell/web/app.js
+++ b/Py4GW_Reforged_Launcher/pywebview_shell/web/app.js
@@ -1635,21 +1635,29 @@ function updateSteamLoginFieldVisibility() {
   document.getElementById("steam-hide-identity").style.display = useSteam ? "none" : "";
   document.getElementById("steam-hide-autologin").style.display = useSteam ? "none" : "";
   document.getElementById("steam-anchor-row").style.display = useSteam ? "" : "none";
+  document.getElementById("steam-hide-client").style.display = useSteam ? "none" : "";
+  document.getElementById("steam-client-note").style.display = useSteam ? "block" : "none";
 }
 
 async function onSaveProfileClick() {
+  const useSteam = document.getElementById("edit-steam-login").checked;
+  // RELAY 094 follow-up: found live that a stale/wrong executable_path
+  // (e.g. left over from before the toggle existed) silently breaks Steam
+  // process-attach matching -- hiding the fields isn't enough on its own
+  // since a hidden input still submits its last value, so these are
+  // cleared outright whenever Steam login is on, not just visually hidden.
   const data = {
     id: editingProfileId || undefined,
     name: document.getElementById("edit-name").value.trim(),
     email: document.getElementById("edit-email").value.trim(),
-    executable_path: document.getElementById("edit-path").value.trim(),
-    launch_arguments: document.getElementById("edit-args").value.trim(),
+    executable_path: useSteam ? "" : document.getElementById("edit-path").value.trim(),
+    launch_arguments: useSteam ? "" : document.getElementById("edit-args").value.trim(),
     py4gw_enabled: document.getElementById("edit-py4gw").checked,
     gmod_enabled: document.getElementById("edit-gmod").checked,
     auto_login_enabled: document.getElementById("edit-autologin").checked,
     auto_select_character_enabled: document.getElementById("edit-autoselect").checked,
     character_name: document.getElementById("edit-charname").value.trim(),
-    use_steam_login: document.getElementById("edit-steam-login").checked,
+    use_steam_login: useSteam,
     steam_account_anchor: document.getElementById("edit-steam-anchor").value.trim(),
     py4gw_dll_path: document.getElementById("edit-py4gw-dll-path").value.trim(),
     gmod_dll_path: document.getElementById("edit-gmod-dll-path").value.trim(),

--- a/Py4GW_Reforged_Launcher/pywebview_shell/web/app.js
+++ b/Py4GW_Reforged_Launcher/pywebview_shell/web/app.js
@@ -1510,6 +1510,9 @@ function openEditDrawer(profileId) {
   document.getElementById("edit-autologin").checked = p ? !!p.auto_login_enabled : false;
   document.getElementById("edit-autoselect").checked = p ? !!p.auto_select_character_enabled : false;
   document.getElementById("edit-charname").value = p ? p.character_name || "" : "";
+  document.getElementById("edit-steam-login").checked = p ? !!p.use_steam_login : false;
+  document.getElementById("edit-steam-anchor").value = p ? p.steam_account_anchor || "" : "";
+  updateSteamLoginFieldVisibility();
 
   // RELAY 024: Mods/Window tab fields.
   document.getElementById("edit-py4gw-dll-path").value = p ? p.py4gw_dll_path || "" : "";
@@ -1621,6 +1624,19 @@ async function onAddPluginClick() {
   }
 }
 
+// RELAY 094: hides email/password/auto-select/character-name (meaningless
+// for a Steam-authenticated session -- Apo confirmed there's no email Py4GW
+// can read from memory for a Steam-linked account) and shows the anchor
+// field instead, whenever "Use Steam login" is on. Called both from the
+// checkbox's own onchange and from openEditDrawer on initial render, same
+// pattern as every other drawer-visibility toggle in this file.
+function updateSteamLoginFieldVisibility() {
+  const useSteam = document.getElementById("edit-steam-login").checked;
+  document.getElementById("steam-hide-identity").style.display = useSteam ? "none" : "";
+  document.getElementById("steam-hide-autologin").style.display = useSteam ? "none" : "";
+  document.getElementById("steam-anchor-row").style.display = useSteam ? "" : "none";
+}
+
 async function onSaveProfileClick() {
   const data = {
     id: editingProfileId || undefined,
@@ -1633,6 +1649,8 @@ async function onSaveProfileClick() {
     auto_login_enabled: document.getElementById("edit-autologin").checked,
     auto_select_character_enabled: document.getElementById("edit-autoselect").checked,
     character_name: document.getElementById("edit-charname").value.trim(),
+    use_steam_login: document.getElementById("edit-steam-login").checked,
+    steam_account_anchor: document.getElementById("edit-steam-anchor").value.trim(),
     py4gw_dll_path: document.getElementById("edit-py4gw-dll-path").value.trim(),
     gmod_dll_path: document.getElementById("edit-gmod-dll-path").value.trim(),
     script_path: document.getElementById("edit-script-path").value.trim(),

--- a/Py4GW_Reforged_Launcher/pywebview_shell/web/index.html
+++ b/Py4GW_Reforged_Launcher/pywebview_shell/web/index.html
@@ -389,10 +389,12 @@
           <h4 style="margin-bottom:8px">Identity</h4>
           <label class="field-label">Profile name</label>
           <input class="field-input" id="edit-name" placeholder="e.g. Aldric Vale">
-          <label class="field-label">Account email</label>
-          <input class="field-input" id="edit-email" placeholder="account@email.com">
-          <label class="field-label">Password</label>
-          <input class="field-input" id="edit-password" type="password" placeholder="••••••••">
+          <div id="steam-hide-identity">
+            <label class="field-label">Account email</label>
+            <input class="field-input" id="edit-email" placeholder="account@email.com">
+            <label class="field-label">Password</label>
+            <input class="field-input" id="edit-password" type="password" placeholder="••••••••">
+          </div>
         </div>
         <div>
           <h4 style="margin-bottom:8px">Client</h4>
@@ -406,10 +408,23 @@
         </div>
         <div>
           <h4 style="margin-bottom:8px">Auto-Login</h4>
-          <div class="pal-row"><span>Enable auto-login</span><input type="checkbox" id="edit-autologin"></div>
-          <div class="pal-row"><span>Auto-select character</span><input type="checkbox" id="edit-autoselect"></div>
-          <label class="field-label">Character name to auto-select</label>
-          <input class="field-input" id="edit-charname" placeholder="in-game character name">
+          <!-- RELAY 094: Steam-linked accounts have no email Py4GW can read
+               from memory, and no suitable replacement (Apo confirmed
+               directly: "Steam accounts dont have that... the user will
+               have to set up an alias") -- so email/password/auto-select
+               are all meaningless once this is on, and get hidden rather
+               than left sitting there disabled. -->
+          <div class="pal-row"><span>Use Steam login</span><input type="checkbox" id="edit-steam-login" onchange="updateSteamLoginFieldVisibility()"></div>
+          <div id="steam-anchor-row" style="display:none">
+            <label class="field-label">Account anchor (only needed if widgets/scripts don't work)</label>
+            <input class="field-input" id="edit-steam-anchor" placeholder="any short label to identify this account">
+          </div>
+          <div id="steam-hide-autologin">
+            <div class="pal-row"><span>Enable auto-login</span><input type="checkbox" id="edit-autologin"></div>
+            <div class="pal-row"><span>Auto-select character</span><input type="checkbox" id="edit-autoselect"></div>
+            <label class="field-label">Character name to auto-select</label>
+            <input class="field-input" id="edit-charname" placeholder="in-game character name">
+          </div>
         </div>
       </div>
 

--- a/Py4GW_Reforged_Launcher/pywebview_shell/web/index.html
+++ b/Py4GW_Reforged_Launcher/pywebview_shell/web/index.html
@@ -398,13 +398,25 @@
         </div>
         <div>
           <h4 style="margin-bottom:8px">Client</h4>
-          <label class="field-label">Gw.exe path</label>
-          <div class="path-browse-row">
-            <input class="field-input" id="edit-path" placeholder="C:\Games\Guild Wars\Gw.exe">
-            <button class="ghost-btn" onclick="onBrowsePathClick('edit-path','Guild Wars executable','*.exe')">Browse…</button>
+          <!-- RELAY 094 follow-up: found live that leaving these editable
+               under Steam login let a profile drift back to pointing at
+               steam.exe (the old pre-toggle habit), which then silently
+               broke process-attach matching. Steam owns the actual launch
+               once the toggle is on, so these have no real use anymore --
+               hidden, and cleared on save (onSaveProfileClick) rather than
+               just visually hidden, so a stale value can't linger unseen. -->
+          <div id="steam-hide-client">
+            <label class="field-label">Gw.exe path</label>
+            <div class="path-browse-row">
+              <input class="field-input" id="edit-path" placeholder="C:\Games\Guild Wars\Gw.exe">
+              <button class="ghost-btn" onclick="onBrowsePathClick('edit-path','Guild Wars executable','*.exe')">Browse…</button>
+            </div>
+            <label class="field-label">Extra launch args</label>
+            <input class="field-input" id="edit-args" placeholder="-optional -flags">
           </div>
-          <label class="field-label">Extra launch args</label>
-          <input class="field-input" id="edit-args" placeholder="-optional -flags">
+          <p id="steam-client-note" style="display:none;font-size:11px;color:var(--faint,#5f6491);line-height:1.5;margin:4px 0 0">
+            Launched via Steam (steam://rungameid/29720) -- no path or launch args needed.
+          </p>
         </div>
         <div>
           <h4 style="margin-bottom:8px">Auto-Login</h4>


### PR DESCRIPTION
## Summary

Adds real Steam-login support to GW1 profiles, plus a small, unrelated window-position/size fix riding along in the same branch (both small, same "bundled" framing as #13).

**1. "Use Steam login" toggle + a real Steam launch/attach path.** Steam-linked accounts have no email Py4GW can read from memory at all, and no ArenaNet credentials to auto-fill — so a Steam profile needed a genuinely different launch shape, not a variant of the direct one. Toggling it on hides email/password/auto-select-character/character-name (all meaningless for a Steam-authenticated session) and the Gw.exe path/launch-args fields (Steam owns the actual launch — these have no use here either, more on why below).

The old way of doing this — `executable_path` pointed at `steam.exe` with `-applaunch 29720` as launch args — never actually worked: it patches/injects the wrong process (`steam.exe`, not the real `Gw.exe`), then scans for a follow-up process at the same *path*, which the real client never matches. The new path launches via the `steam://rungameid/29720` URI (Steam owns process creation from there), discovers the real `Gw.exe` by name + creation time, then runs multiclient patch / gMod / Py4GW injection against that already-running process, best-effort where the direct path could rely on a suspended one.

A handful of real bugs surfaced fixing this properly, each found via an actual live test against a real Steam-linked account, not assumed fixed:
- A 5s process-spawn timeout was too short for a cold Steam launch (DRM/update checks before `Gw.exe` even exists as a process) — bumped to 30s.
- A stale `executable_path` (left over from the old `steam.exe` approach, or just drifted back to it since the field was still editable) permanently broke process-attach matching. Fixed by dropping the executable_path requirement entirely for Steam profiles — a Steam-linked account can only be one account at a time, so the multibox-precision reason that validation exists for the direct-launch case doesn't apply here.
- Clearing that field on a Steam profile exposed a real, pre-existing data-loss bug: two profiles that are both blank on path *and* character name collided in the account-store's dedup key and silently merged into one on the next load. Guarded the same way an existing email-key fix already does.
- The game's own splash/patch dialog and its real 3D client window are two genuinely different Win32 window classes (`ArenaNet_Dialog_Class` vs. `ArenaNet_Dx_Window_Class`, confirmed via a live capture) — injection timing now waits specifically for the latter, so a multi-minute content-update cycle (live-tested end to end, including several process exit/restart transitions during the update) never gets mistaken for "ready." This fix applies to both the Steam and the existing direct-launch path, since they share the same wait function.

**2. Remember the launcher window's last position/size.** Small, unrelated polish item riding along — `create_window` was hardcoded to a fixed size/position on every launch, with no persistence at all. Now saved (debounced) on move/resize/maximize and restored on next launch, clamped against the current monitor layout so a saved position from a since-disconnected second monitor can't strand the window off-screen.

## Notes

- Companion PR against `Py4GW_Reforged_Native`: apoguita/Py4GW_Reforged_Native#4 adds the ini-based account-anchor fallback this needs for the per-account settings folder (and everything that depends on it — widgets, HeroAI, etc.) to actually work for Steam accounts. **This PR alone already delivers a real, working Steam launch/inject** — the settings-folder/widgets half specifically needs the companion PR too.
- Elevation/UAC is flagged, not solved, for the Steam path — no reference implementation exists to characterize it against (GWxLauncher's own Steam path has no elevation handling either), and it's untested against a genuinely locked-down install.

## Test plan

- [x] Full suite green: 111/111
- [x] Live-tested against a real Steam-linked GW1 account: URI launch → process attach → multiclient patch → Py4GW injection, repeatedly, across multiple fix iterations
- [x] Live-tested a forced full client update (Steam .dat replaced + an outdated `Gw.exe`, several minutes long): the client cycled through multiple splash-window/process transitions before finishing; the launcher correctly waited through the whole thing and injected once the real window actually appeared, never prematurely
- [x] Live-tested mixed launches — Steam and ArenaNet-direct profiles both working side by side
- [x] Window geometry: move/resize → restart, maximize → restart, un-maximize (confirmed it restores the pre-maximize size, not the maximized one), a simulated disconnected-monitor position (confirmed it falls back onto a real screen), and an immediate resize-then-close (confirmed the debounced save isn't lost)
