### PR TITLE
Fix Skills Unlocker YMLAD and I Am Unstoppable chains

### DIFF
--- a/HeroAI/combat.py
+++ b/HeroAI/combat.py
@@ -189,6 +189,7 @@ class CombatClass:
         self.never_rampage_alone = GLOBAL_CACHE.Skill.GetID("Never_Rampage_Alone")
         self.whirlwind_attack = GLOBAL_CACHE.Skill.GetID("Whirlwind_Attack")
         self.heroic_refrain = GLOBAL_CACHE.Skill.GetID("Heroic_Refrain")
+        self.make_your_time = GLOBAL_CACHE.Skill.GetID("Make_Your_Time")
         self.natures_blessing = GLOBAL_CACHE.Skill.GetID("Natures_Blessing")
         self.relentless_assault = GLOBAL_CACHE.Skill.GetID("Relentless_Assault")
         self.great_dwarf_weapon = GLOBAL_CACHE.Skill.GetID("Great_Dwarf_Weapon")
@@ -733,6 +734,20 @@ class CombatClass:
             return self.cached_data.GetActiveScanRange()
         return Range.Spellcast.value if self.in_aggro else Range.Earshot.value
 
+    @staticmethod
+    def _get_attribute_level(attribute_name: str) -> int:
+        """Return the player's live attribute level, including active bonuses."""
+        attributes = Agent.GetAttributes(Player.GetAgentID())
+        attribute = next(
+            (item for item in attributes if item.GetName() == attribute_name),
+            None,
+        )
+        return int(getattr(attribute, "level", 0) or 0)
+
+    def _heroic_refrain_needs_self_bootstrap(self) -> bool:
+        """Heroic Refrain must be reapplied to self until Leadership reaches 20."""
+        return self._get_attribute_level("Leadership") < 20
+
 
 
     def GetAppropiateTarget(self, slot: int) -> int:
@@ -775,8 +790,11 @@ class CombatClass:
             return _lowest_ally
 
         if self.skills[slot].skill_id == self.heroic_refrain:
+            if self._heroic_refrain_needs_self_bootstrap():
+                return Player.GetAgentID()
             if not self.HasEffect(Player.GetAgentID(), self.heroic_refrain):
                 return Player.GetAgentID()
+            return TargetLowestAlly(filter_skill_id=self.heroic_refrain)
 
         if target_allegiance == Skilltarget.Enemy:
             v_target = preferred_enemy_target
@@ -1033,6 +1051,17 @@ class CombatClass:
         """ Check if the skill is a resurrection skill and the target is dead """
         if self.skills[slot].custom_skill_data.Nature == SkillNature.Resurrection.value:
             return bool(IsResurrectablePartyMember(vTarget) and Routines.Checks.Agents.IsDead(vTarget))
+
+        if self.skills[slot].skill_id == self.make_your_time:
+            from .utils import IsPartyMember
+
+            candidates = AgentArray.GetAllyArray() + AgentArray.GetSpiritPetArray()
+            candidates = AgentArray.Filter.ByDistance(candidates, Player.GetXY(), Range.Earshot.value)
+            candidates = AgentArray.Filter.ByCondition(
+                candidates,
+                lambda agent_id: Agent.IsAlive(agent_id) and IsPartyMember(agent_id, self.cached_data),
+            )
+            return len(candidates) >= 3
 
 
         if self.skills[slot].custom_skill_data.Conditions.UniqueProperty:
@@ -1688,8 +1717,14 @@ class CombatClass:
             skill_type == SkillType.WeaponSpell.value
             and conditions.AllowOverlapWeaponSpell
         )
+        heroic_refrain_bootstrap = (
+            skill_id == self.heroic_refrain
+            and v_target == player_id
+            and self._heroic_refrain_needs_self_bootstrap()
+        )
         if (
             target_allegiance != Skilltarget.NonWeaponSpelledAlly.value
+            and not heroic_refrain_bootstrap
             and self.HasEffect(v_target, skill_id, exact_weapon_spell=exact_weapon_spell)
         ):
             self.in_casting_routine = False

--- a/HeroAI/custom_skill_src/paragon.py
+++ b/HeroAI/custom_skill_src/paragon.py
@@ -51,7 +51,7 @@ class ParagonSkills:
         skill.SkillType = SkillType.Skill.value
         skill.TargetAllegiance = Skilltarget.OtherAlly.value
         skill.Nature = SkillNature.Buff.value
-        skill.Conditions.LessLife = 0.75
+        skill.Conditions.LessLife = 0.30
         skill.Conditions.TargetingStrict = True
         skill_data[skill.SkillID] = skill
 

--- a/Py4GWCoreLib/SessionLogger.py
+++ b/Py4GWCoreLib/SessionLogger.py
@@ -1,0 +1,56 @@
+"""Small file-backed session logger for runtime diagnostics."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import os
+import threading
+
+
+class SessionLogger:
+    def __init__(self, name: str):
+        self.name = "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in str(name)) or "session"
+        self._path = ""
+        self._lock = threading.Lock()
+
+    @property
+    def path(self) -> str:
+        self._ensure_path()
+        return self._path
+
+    def _ensure_path(self) -> None:
+        if self._path:
+            return
+        try:
+            import PySystem
+
+            root = str(PySystem.Console.get_projects_path() or ".")
+            log_dir = os.path.join(root, "Logs", "Sessions")
+            os.makedirs(log_dir, exist_ok=True)
+            stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            self._path = os.path.join(log_dir, f"{self.name}_{stamp}_{os.getpid()}.log")
+        except Exception:
+            # Diagnostics must never stop the bot.
+            self._path = ""
+
+    def write(self, message: str) -> None:
+        self._ensure_path()
+        if not self._path:
+            return
+        line = f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]}] {message}\n"
+        try:
+            with self._lock:
+                with open(self._path, "a", encoding="utf-8") as handle:
+                    handle.write(line)
+        except Exception:
+            pass
+
+
+_LOGGERS: dict[str, SessionLogger] = {}
+
+
+def get_session_logger(name: str) -> SessionLogger:
+    key = str(name)
+    if key not in _LOGGERS:
+        _LOGGERS[key] = SessionLogger(key)
+    return _LOGGERS[key]

--- a/Py4GWCoreLib/botting_src/helpers_src/Upkeepers.py
+++ b/Py4GWCoreLib/botting_src/helpers_src/Upkeepers.py
@@ -42,6 +42,18 @@ class _Upkeepers:
                 Settings().set_runtime_combat_range_mode_override(None)
                 self._hero_ai_legacy_range_override_applied = False
 
+        def ensure_botting_combat_options() -> None:
+            """An active bot HeroAI request must not inherit a stale dialog pause."""
+            account_email = Player.GetAccountEmail()
+            current_options = GLOBAL_CACHE.ShMem.GetHeroAIOptionsFromEmail(account_email) if account_email else None
+            if current_options is None:
+                return
+
+            if not current_options.Targeting or not current_options.Combat:
+                current_options.Targeting = True
+                current_options.Combat = True
+                GLOBAL_CACHE.ShMem.SetHeroAIOptionsByEmail(account_email, current_options)
+
         while True:   
             pause_requested = bool(getattr(self._config.upkeep, "hero_ai_paused", None) and self._config.upkeep.hero_ai_paused.is_active())
 
@@ -87,6 +99,7 @@ class _Upkeepers:
                 continue
 
             set_botting_range_mode(True)
+            ensure_botting_combat_options()
               
             if not (self.parent.config.pause_on_danger_fn()):
                 self.cancel_movement_triggered = False

--- a/Py4GWCoreLib/botting_src/subclases_src/DIALOGS_src.py
+++ b/Py4GWCoreLib/botting_src/subclases_src/DIALOGS_src.py
@@ -40,12 +40,20 @@ class _DIALOGS:
         
     def _coro_at_xy(self, x: float, y: float, dialog:int):
         yield from self._coro_pause_hero_ai()
-        yield from self.parent.Interact._coro_with_npc_at_xy(x, y, dialog_id=dialog)
+        try:
+            yield from self.parent.Interact._coro_with_npc_at_xy(x, y, dialog_id=dialog)
+        except Exception:
+            yield from self._coro_restore_hero_ai()
+            raise
         yield from self._coro_restore_hero_ai()
         
     def _coro_with_model(self, model_id: int, dialog:int):
         yield from self._coro_pause_hero_ai()
-        yield from self.parent.Interact._coro_with_model(model_id=model_id, dialog_id=dialog)
+        try:
+            yield from self.parent.Interact._coro_with_model(model_id=model_id, dialog_id=dialog)
+        except Exception:
+            yield from self._coro_restore_hero_ai()
+            raise
         yield from self._coro_restore_hero_ai()
     
     #region Yield Steps (ys_)

--- a/Py4GWCoreLib/botting_src/subclases_src/EVENTS_src.py
+++ b/Py4GWCoreLib/botting_src/subclases_src/EVENTS_src.py
@@ -146,72 +146,75 @@ class _EVENTS:
         from ...GlobalCache import GLOBAL_CACHE
         from ...Agent import Agent
         from ...Player import Player
+        from ...Pathing import AutoPathing
         from ...Py4GWcorelib import Utils
         from ...enums import Range
-        from ..helpers_src.HeroAICombatRange import hero_ai_combat_detected
         bot = self.parent
-        
-        if Routines.Checks.Party.IsPartyWiped() or GLOBAL_CACHE.Party.IsPartyDefeated():
-                    print("Party wiped, aborting OnPartyMemberBehind")
+
+        try:
+            print("Party member dead behind; pausing route for recovery")
+            recovery_pass = 0
+            while True:
+                if Routines.Checks.Party.IsPartyWiped() or GLOBAL_CACHE.Party.IsPartyDefeated():
+                    print("Party wiped during member recovery; handing off to wipe recovery")
                     return
-                
-        print ("Party Member dead behind")
-        # Find a dead party member
-        dead_player = Routines.Party.GetDeadPartyMemberID()
-        if dead_player == 0:
-            bot.config.FSM.resume()
-            return
-        if not Agent.IsValid(dead_player):
-            bot.config.FSM.resume()
-            return
 
-        # If we're in danger, end combat first (wait until safe)
-        while Routines.Checks.Agents.InDanger():
-            # You can replace with your combat reset routine if you have one
-            #print ("In danger, waiting to be safe before moving to dead party member")
-            if Routines.Checks.Party.IsPartyWiped() or GLOBAL_CACHE.Party.IsPartyDefeated():
-                    print("Party wiped, aborting OnPartyMemberBehind")
+                dead_player = Routines.Party.GetDeadPartyMemberID()
+                if dead_player == 0:
+                    print("All party members revived; resuming route")
                     return
-                
-            yield from Routines.Yield.wait(1000)  
+                if not Agent.IsValid(dead_player):
+                    yield from Routines.Yield.wait(500)
+                    continue
 
-        print ("Safe now, moving to dead party member")
-        # Now safe → move to the dead party member
-        dead_player = Routines.Party.GetDeadPartyMemberID()
-        if dead_player == 0:
-            print("All party members alive!")
+                # Finish nearby combat before backtracking so survivors do not
+                # drag a mob train onto the corpse.
+                while Routines.Checks.Agents.InDanger():
+                    if Routines.Checks.Party.IsPartyWiped() or GLOBAL_CACHE.Party.IsPartyDefeated():
+                        return
+                    yield from Routines.Yield.wait(500)
+
+                dead_player = Routines.Party.GetDeadPartyMemberID()
+                if dead_player == 0:
+                    continue
+                if not Agent.IsValid(dead_player):
+                    yield from Routines.Yield.wait(500)
+                    continue
+
+                dead_pos = Agent.GetXY(dead_player)
+                distance = Utils.Distance(dead_pos, Player.GetXY())
+                if distance > Range.Spellcast.value:
+                    print(
+                        f"Backtracking to dead party member {dead_player} "
+                        f"at ({dead_pos[0]:.0f}, {dead_pos[1]:.0f}), distance={distance:.0f}"
+                    )
+                    path = yield from AutoPathing().get_path_to(dead_pos[0], dead_pos[1])
+                    if not path:
+                        path = [(dead_pos[0], dead_pos[1])]
+                    yield from Routines.Yield.Movement.FollowPath(
+                        path_points=path,
+                        custom_exit_condition=lambda target=dead_player: (
+                            Routines.Checks.Party.IsPartyWiped()
+                            or GLOBAL_CACHE.Party.IsPartyDefeated()
+                            or not Agent.IsValid(target)
+                            or not Agent.IsDead(target)
+                        ),
+                        tolerance=Range.Spellcast.value,
+                        timeout=30000,
+                    )
+
+                if Routines.Checks.Party.IsPartyWiped() or GLOBAL_CACHE.Party.IsPartyDefeated():
+                    return
+
+                # Gather surviving heroes at the corpse and actually wait for
+                # HeroAI to perform resurrection. Repeat for multiple corpses.
+                recovery_pass += 1
+                print(f"Waiting at corpse for HeroAI resurrection (pass {recovery_pass})")
+                yield from bot.helpers.Multibox._pixel_stack()
+                yield from Routines.Yield.wait(2500)
+        finally:
             bot.config.FSM.resume()
-            return
-        if not Agent.IsValid(dead_player):
-            bot.config.FSM.resume()
-            return
-
-        dead_pos = Agent.GetXY(dead_player)
-        if Utils.Distance(dead_pos, Player.GetXY()) <= Range.Spellcast.value:
-            print("Dead party member already within spellcast range")
-            bot.config.FSM.resume()
-            return
-
-        exit_movement_condition = lambda: Routines.Checks.Party.IsPartyWiped() or GLOBAL_CACHE.Party.IsPartyDefeated()
-
-        path = [(dead_pos[0], dead_pos[1])]
-        result = (yield from Routines.Yield.Movement.FollowPath(
-            path,
-            custom_exit_condition=exit_movement_condition,
-            tolerance=Range.Spellcast.value,
-            timeout=30000,
-        ))
-        yield from Routines.Yield.wait(100)
-        if not result:
-            print("Failed to move to dead party member")
-            bot.config.FSM.resume()
-            return
-        else:
-            print("Arrived at dead party member, waiting for revival")
-            
-        yield from bot.helpers.Multibox._pixel_stack()
-
-        bot.config.FSM.resume()
+            yield
             
 
     def OnDeathCallback(self, callback: Callable[[], None]) -> None:

--- a/Py4GWCoreLib/routines_src/yield_src/agents.py
+++ b/Py4GWCoreLib/routines_src/yield_src/agents.py
@@ -188,10 +188,24 @@ class Agents:
     @staticmethod
     def InteractWithAgentXY(x: float, y: float, timeout_ms: int = 5000, tolerance: float = 200.0):
         from ...Py4GWcorelib import ConsoleLog, Utils
-        yield from Agents.TargetNearestNPCXY(x, y, 100)
+        from ...SessionLogger import get_session_logger
+        from ...Map import Map
+        from ...Player import Player
+
+        log = get_session_logger("AgentInteraction")
+        # NPC positions can drift from route coordinates, especially in
+        # outposts. Keep this lookup consistent with the interaction type.
+        target_distance = max(200.0, float(tolerance))
+        log.write(
+            f"InteractWithAgentXY start map={Map.GetMapID()} player_xy={Player.GetXY()} "
+            f"requested_xy=({x}, {y}) search_radius={target_distance} current_target={Player.GetTargetID()}"
+        )
+        yield from Agents.TargetNearestNPCXY(x, y, target_distance)
         target_id = Player.GetTargetID()
+        log.write(f"InteractWithAgentXY target_result target_id={target_id}")
         if not target_id:
-            ConsoleLog("InteractWithGadgetXY", "No target after targeting.")
+            ConsoleLog("InteractWithAgentXY", "No NPC target after targeting.")
+            log.write("InteractWithAgentXY failure reason=no_npc_target")
             return False
 
         yield from YieldPlayer.InteractTarget()
@@ -207,7 +221,7 @@ class Agents:
                 break
 
             if since_reissue >= reissue_interval:
-                yield from Agents.TargetNearestGadgetXY(x, y, 100)
+                yield from Agents.TargetNearestNPCXY(x, y, target_distance)
                 yield from YieldPlayer.InteractTarget()
                 since_reissue = 0
 
@@ -217,9 +231,11 @@ class Agents:
 
         if elapsed >= timeout_ms:
             ConsoleLog("InteractWithAgentXY", "TIMEOUT waiting to reach target range.")
+            log.write(f"InteractWithAgentXY failure reason=timeout target_id={target_id} elapsed_ms={elapsed}")
             return False
 
         yield from wait(500)
+        log.write(f"InteractWithAgentXY success target_id={target_id}")
         return True
 
     @staticmethod

--- a/Widgets/Automation/Bots/SkillsUnlocker/EOTN_SKILL_UNLOCKER.py
+++ b/Widgets/Automation/Bots/SkillsUnlocker/EOTN_SKILL_UNLOCKER.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Tuple, Optional, Callable, Generator
+from typing import Any, List, Tuple, Optional, Callable, Generator
 import types
 import Py4GW
 import PyImGui
@@ -8,9 +8,11 @@ from Py4GWCoreLib import ImGui,GLOBAL_CACHE
 from Py4GWCoreLib.py4gwcorelib_src.Settings import Settings
 from Py4GWCoreLib.Routines import Routines
 from Py4GWCoreLib.ImGui import ImGui
+from Py4GWCoreLib.SessionLogger import get_session_logger
 
 BOT_NAME = "Skills Unlocker"
 MODULE_NAME = BOT_NAME
+SESSION_LOG = get_session_logger(BOT_NAME)
 
 TEXTURE = os.path.join(PySystem.Console.get_projects_path(), "Bots", "SkillsUnlocker", "skills_unlocker.png")
 ICONS_PATH = os.path.join(PySystem.Console.get_projects_path(), "Bots", "SkillsUnlocker", "icons")
@@ -101,6 +103,253 @@ def AddHenchies():
         yield from Routines.Yield.wait(250)
 
 
+SIF_SHADOWHUNTER_MODEL_IDS = (6398, 6347, 6348)
+SIF_SHADOWHUNTER_XY = (14380.0, 23968.0)
+OUTRUNNER_REMLOK_XY = (-10926.0, 24732.0)
+JAGA_SOUTH_BLESSING_XY = (-9088.0, -22811.0)
+JAGA_SOUTH_BLESSING_MODEL_ID = 6425
+DRAKKAR_SIFHALLA_BLESSING_XY = (7367.0, 23752.0)
+DRAKKAR_SIFHALLA_BLESSING_MODEL_ID = 6425
+DRAKKAR_SEPULCHRE_BLESSING_XY = (-11603.0, 24975.0)
+DRAKKAR_SEPULCHRE_BLESSING_MODEL_ID = 6431
+SEPULCHRE_LEVEL1_ENTRANCE_BLESSING_XY = (-7571.0, -16263.0)
+SEPULCHRE_LEVEL1_ENTRANCE_BLESSING_MODEL_ID = 5916
+
+
+def _interact_sif_shadowhunter(dialog_id: int) -> Generator[Any, Any, bool]:
+    """Interact with the live Sif variant without relying on NPCMinipetArray."""
+    from Py4GWCoreLib.AgentArray import AgentArray
+    from Py4GWCoreLib.Context import GWContext
+    from Py4GWCoreLib.Py4GWcorelib import Utils
+
+    player_xy = Player.GetXY()
+    shared_agents = AgentArray.GetAgentArray()
+    context = GWContext.AgentArray.GetContext()
+    context_agents = context.GetAgentArray() if context is not None else []
+    all_agents = list(dict.fromkeys([*shared_agents, *context_agents]))
+    resolution = "model_id"
+    candidates = [
+        agent_id
+        for agent_id in all_agents
+        if Agent.GetModelID(agent_id) in SIF_SHADOWHUNTER_MODEL_IDS
+    ]
+
+    if not candidates:
+        resolution = "decoded_name"
+        candidates = [
+            agent_id
+            for agent_id in all_agents
+            if "sif shadowhunter" in Agent.GetNameByID(agent_id).strip().lower()
+        ]
+
+    if not candidates:
+        resolution = "npc_at_known_position"
+        candidates = [
+            agent_id
+            for agent_id in all_agents
+            if Agent.IsLiving(agent_id)
+            and Agent.IsNPC(agent_id)
+            and Utils.Distance(SIF_SHADOWHUNTER_XY, Agent.GetXY(agent_id)) <= 250.0
+        ]
+
+    if not candidates:
+        nearby = []
+        for agent_id in all_agents:
+            if not Agent.IsLiving(agent_id):
+                continue
+            agent_xy = Agent.GetXY(agent_id)
+            distance = Utils.Distance(player_xy, agent_xy)
+            if distance <= 1500.0:
+                nearby.append(
+                    f"id={agent_id},model={Agent.GetModelID(agent_id)},name={Agent.GetNameByID(agent_id)!r},"
+                    f"xy={agent_xy},distance={distance:.1f},npc={Agent.IsNPC(agent_id)}"
+                )
+        message = (
+            f"sif_lookup_failed map={Map.GetMapID()} player_xy={player_xy} "
+            f"models={SIF_SHADOWHUNTER_MODEL_IDS} shared_count={len(shared_agents)} "
+            f"context_count={len(context_agents)} merged_count={len(all_agents)} nearby={nearby}"
+        )
+        SESSION_LOG.write(message)
+        ConsoleLog(MODULE_NAME, "Sif Shadowhunter was not found in the live agent array.", Console.MessageType.Error)
+        bot.config.state_description = "Blocked: Sif Shadowhunter not found"
+        # A self-managed state advances when its generator returns. Keep this
+        # state alive so the route cannot leave Sifhalla after failed dialog.
+        while bot.config.fsm_running:
+            yield from Routines.Yield.wait(1000)
+        return False
+
+    agent_id = min(candidates, key=lambda candidate: Utils.Distance(player_xy, Agent.GetXY(candidate)))
+    model_id = Agent.GetModelID(agent_id)
+    agent_xy = Agent.GetXY(agent_id)
+    SESSION_LOG.write(
+        f"sif_lookup_success map={Map.GetMapID()} agent_id={agent_id} model_id={model_id} "
+        f"agent_name={Agent.GetNameByID(agent_id)!r} agent_xy={agent_xy} player_xy={player_xy} "
+        f"dialog={hex(dialog_id)} resolution={resolution} shared_count={len(shared_agents)} "
+        f"context_count={len(context_agents)}"
+    )
+
+    yield from bot.Dialogs._coro_pause_hero_ai()
+    yield from Routines.Yield.Player.InteractAgent(agent_id)
+    yield from Routines.Yield.wait(500)
+    Player.SendDialog(dialog_id)
+    yield from Routines.Yield.wait(500)
+    yield from bot.Dialogs._coro_restore_hero_ai()
+    SESSION_LOG.write(
+        f"sif_dialog_sent agent_id={agent_id} model_id={model_id} dialog={hex(dialog_id)}"
+    )
+    return True
+
+
+def _interact_outrunner_remlok(dialog_id: int) -> Generator[Any, Any, bool]:
+    """Interact with Remlok from the full live array, not NPCMinipetArray."""
+    from Py4GWCoreLib.AgentArray import AgentArray
+    from Py4GWCoreLib.Context import GWContext
+    from Py4GWCoreLib.Py4GWcorelib import Utils
+
+    player_xy = Player.GetXY()
+    shared_agents = AgentArray.GetAgentArray()
+    context = GWContext.AgentArray.GetContext()
+    context_agents = context.GetAgentArray() if context is not None else []
+    all_agents = list(dict.fromkeys([*shared_agents, *context_agents]))
+
+    resolution = "decoded_name"
+    candidates = [
+        agent_id
+        for agent_id in all_agents
+        if Agent.IsLiving(agent_id)
+        and "outrunner remlok" in Agent.GetNameByID(agent_id).strip().lower()
+    ]
+
+    if not candidates:
+        resolution = "npc_at_known_position"
+        candidates = [
+            agent_id
+            for agent_id in all_agents
+            if Agent.IsLiving(agent_id)
+            and Agent.IsNPC(agent_id)
+            and Utils.Distance(OUTRUNNER_REMLOK_XY, Agent.GetXY(agent_id)) <= 300.0
+        ]
+
+    if not candidates:
+        nearby = []
+        for agent_id in all_agents:
+            if not Agent.IsLiving(agent_id):
+                continue
+            agent_xy = Agent.GetXY(agent_id)
+            distance = Utils.Distance(OUTRUNNER_REMLOK_XY, agent_xy)
+            if distance <= 1500.0:
+                nearby.append(
+                    f"id={agent_id},model={Agent.GetModelID(agent_id)},name={Agent.GetNameByID(agent_id)!r},"
+                    f"xy={agent_xy},distance_to_remlok={distance:.1f},npc={Agent.IsNPC(agent_id)}"
+                )
+        message = (
+            f"remlok_lookup_failed map={Map.GetMapID()} player_xy={player_xy} "
+            f"target_xy={OUTRUNNER_REMLOK_XY} shared_count={len(shared_agents)} "
+            f"context_count={len(context_agents)} merged_count={len(all_agents)} nearby={nearby}"
+        )
+        SESSION_LOG.write(message)
+        ConsoleLog(MODULE_NAME, "Outrunner Remlok was not found in the full live agent array.", Console.MessageType.Error)
+        bot.config.state_description = "Blocked: Outrunner Remlok not found"
+        while bot.config.fsm_running:
+            yield from Routines.Yield.wait(1000)
+        return False
+
+    agent_id = min(
+        candidates,
+        key=lambda candidate: Utils.Distance(OUTRUNNER_REMLOK_XY, Agent.GetXY(candidate)),
+    )
+    model_id = Agent.GetModelID(agent_id)
+    agent_xy = Agent.GetXY(agent_id)
+    SESSION_LOG.write(
+        f"remlok_lookup_success map={Map.GetMapID()} agent_id={agent_id} model_id={model_id} "
+        f"agent_name={Agent.GetNameByID(agent_id)!r} agent_xy={agent_xy} player_xy={player_xy} "
+        f"dialog={hex(dialog_id)} resolution={resolution} shared_count={len(shared_agents)} "
+        f"context_count={len(context_agents)}"
+    )
+
+    yield from bot.Dialogs._coro_pause_hero_ai()
+    yield from Routines.Yield.Player.InteractAgent(agent_id)
+    yield from Routines.Yield.wait(500)
+    Player.SendDialog(dialog_id)
+    yield from Routines.Yield.wait(500)
+    yield from bot.Dialogs._coro_restore_hero_ai()
+    SESSION_LOG.write(
+        f"remlok_dialog_sent agent_id={agent_id} model_id={model_id} dialog={hex(dialog_id)}"
+    )
+    return True
+
+
+def _take_optional_blessing_at_xy(
+    npc_xy: Tuple[float, float],
+    dialog_id: int,
+    preferred_model_id: int = 0,
+    label: str = "blessing",
+) -> Generator[Any, Any, bool]:
+    """Take an optional blessing using the full live-agent array."""
+    from Py4GWCoreLib.AgentArray import AgentArray
+    from Py4GWCoreLib.Context import GWContext
+    from Py4GWCoreLib.Py4GWcorelib import Utils
+
+    shared_agents = AgentArray.GetAgentArray()
+    context = GWContext.AgentArray.GetContext()
+    context_agents = context.GetAgentArray() if context is not None else []
+    all_agents = list(dict.fromkeys([*shared_agents, *context_agents]))
+
+    candidates = []
+    resolution = "preferred_model_at_position"
+    if preferred_model_id:
+        candidates = [
+            agent_id
+            for agent_id in all_agents
+            if Agent.IsLiving(agent_id)
+            and Agent.GetModelID(agent_id) == preferred_model_id
+            and Utils.Distance(npc_xy, Agent.GetXY(agent_id)) <= 350.0
+        ]
+
+    if not candidates:
+        resolution = "nearest_npc_to_captured_position"
+        candidates = [
+            agent_id
+            for agent_id in all_agents
+            if Agent.IsLiving(agent_id)
+            and Agent.IsNPC(agent_id)
+            and Utils.Distance(npc_xy, Agent.GetXY(agent_id)) <= 175.0
+        ]
+
+    if not candidates:
+        SESSION_LOG.write(
+            f"optional_blessing_lookup_failed label={label!r} map={Map.GetMapID()} "
+            f"npc_xy={npc_xy} preferred_model_id={preferred_model_id} "
+            f"shared_count={len(shared_agents)} context_count={len(context_agents)}"
+        )
+        ConsoleLog(
+            MODULE_NAME,
+            f"Optional blessing skipped: {label} NPC was not found.",
+            Console.MessageType.Warning,
+        )
+        return False
+
+    agent_id = min(candidates, key=lambda candidate: Utils.Distance(npc_xy, Agent.GetXY(candidate)))
+    SESSION_LOG.write(
+        f"optional_blessing_lookup_success label={label!r} map={Map.GetMapID()} "
+        f"agent_id={agent_id} model_id={Agent.GetModelID(agent_id)} "
+        f"agent_name={Agent.GetNameByID(agent_id)!r} agent_xy={Agent.GetXY(agent_id)} "
+        f"dialog={hex(dialog_id)} resolution={resolution}"
+    )
+
+    yield from bot.Dialogs._coro_pause_hero_ai()
+    yield from Routines.Yield.Player.InteractAgent(agent_id)
+    yield from Routines.Yield.wait(500)
+    Player.SendDialog(dialog_id)
+    yield from Routines.Yield.wait(500)
+    yield from bot.Dialogs._coro_restore_hero_ai()
+    SESSION_LOG.write(
+        f"optional_blessing_dialog_sent label={label!r} agent_id={agent_id} "
+        f"model_id={Agent.GetModelID(agent_id)} dialog={hex(dialog_id)}"
+    )
+    return True
+
+
 def draw_window_light(
     self,
     main_child_dimensions: Tuple[int, int] = (520, 360),
@@ -111,7 +360,10 @@ def draw_window_light(
 
 
     if not self._config.ini_key_initialized:
-        self._config.ini_key = Settings(f"{f"BottingClass/bot_{self._config.bot_name}"}/{f"bot_{self._config.bot_name}.ini"}", "account").name
+        self._config.ini_key = Settings(
+            f"BottingClass/bot_{self._config.bot_name}/bot_{self._config.bot_name}.ini",
+            "account",
+        ).name
         self._config.ini_key_initialized = True
 
     if not self._config.ini_key:
@@ -123,13 +375,9 @@ def draw_window_light(
         p_open=True,
         flags=PyImGui.WindowFlags.AlwaysAutoResize,
     ):
-                self._draw_main_child(main_child_dimensions, icon_path, iconwidth)
-                if additional_ui:
-                        additional_ui()
-                PyImGui.end_child()
-                PyImGui.end_tab_item()
-
-            
+        self._draw_main_child(main_child_dimensions, icon_path, iconwidth)
+        if additional_ui:
+            additional_ui()
 
     ImGui.End(self._config.ini_key)
 
@@ -626,13 +874,22 @@ def Unlock_winds(bot: Botting) -> None:
 def Unlock_you_move_like_a_dwarf(bot: Botting) -> None:
     bot.States.AddHeader("[Unlock] You Move Like a Dwarf!")
 
+    # The quest giver is in Sifhalla.  Start from a known map so this routine
+    # can be launched from the widget browser's current outpost/map.
+    bot.Map.Travel(target_map_name="Sifhalla")
+    bot.Wait.ForMapLoad(target_map_id=643)
+
     bot.Properties.Enable("pause_on_danger")
     bot.Properties.Disable("halt_on_death")
     bot.Properties.Set("movement_timeout", value=-1)
     bot.Properties.Enable("hero_ai")
 
     # Worthy Deeds (quest for this skill)
-    bot.Move.XYAndDialog(14380, 23968, 0x833A01)  # take quest
+    bot.Move.XY(14380, 23968)
+    bot.States.AddCustomState(
+        lambda: _interact_sif_shadowhunter(0x833A01),
+        "Talk to Sif: take Worthy Deeds",
+    )
 
     bot.Move.XYAndExitMap(8832, 23870, target_map_id=513)
     bot.Wait.ForMapLoad(target_map_id=513)
@@ -658,12 +915,24 @@ def Unlock_you_move_like_a_dwarf(bot: Botting) -> None:
     bot.Wait.ForTime(3000)
     bot.Wait.ForMapLoad(target_map_id=643)
 
-    bot.Move.XYAndDialog(14380, 23968, 0x833A07)  # Rewards
+    bot.Move.XY(14380, 23968)
+    bot.States.AddCustomState(
+        lambda: _interact_sif_shadowhunter(0x833A07),
+        "Talk to Sif: claim YMLAD reward",
+    )
     bot.UI.CancelSkillRewardWindow()    
     bot.States.JumpToStepName("MENU_IDLE")
 
 def Unlock_i_am_unstoppable(bot: Botting) -> None:
     bot.States.AddHeader("[Unlock] I Am Unstoppable!")
+    bot.States.AddCustomState(_anchor, "IAU:TAKE_ANYTHING_YOU_CAN_DO")
+
+    # Stop route progression when a hero dies behind the party. The recovery
+    # routine backtracks to the corpse and waits for HeroAI to resurrect every
+    # dead party member before this quest chain can continue.
+    bot.Events.OnPartyMemberDeadBehindCallback(
+        lambda: bot.Templates.Routines.OnPartyMemberDeathBehind()
+    )
 
     bot.Map.Travel(target_map_name="Sifhalla")
     bot.Wait.ForMapLoad(target_map_id=643)
@@ -674,10 +943,29 @@ def Unlock_i_am_unstoppable(bot: Botting) -> None:
     bot.Properties.Enable("hero_ai")
 
     # --- Part 1: Anything you can do ---
-    bot.Move.XYAndDialog(14380, 23874, 0x833E01)  # Anything you can do
+    bot.Move.XY(14380, 23968)
+    bot.States.AddCustomState(
+        lambda: _interact_sif_shadowhunter(0x833E01),
+        "Talk to Sif: take Anything You Can Do",
+    )
+
+    bot.States.AddCustomState(_anchor, "IAU:HUNT_AVARR_AND_WHITEOUT")
+    bot.Map.Travel(target_map_name="Sifhalla")
+    bot.Wait.ForMapLoad(target_map_id=643)
     bot.Move.XY(14682, 22900)
     bot.Move.XYAndExitMap(17000, 22872, target_map_id=546)
     bot.Wait.ForMapLoad(target_map_id=546)
+
+    bot.Move.XY(*JAGA_SOUTH_BLESSING_XY)
+    bot.States.AddCustomState(
+        lambda: _take_optional_blessing_at_xy(
+            JAGA_SOUTH_BLESSING_XY,
+            0x84,
+            JAGA_SOUTH_BLESSING_MODEL_ID,
+            "Jaga Moraine south shrine bounty",
+        ),
+        "Take Jaga Moraine south shrine blessing",
+    )
 
     bot.Move.XY(-9431, -20124)
     bot.Move.XY(-8441, -13685)
@@ -697,16 +985,56 @@ def Unlock_i_am_unstoppable(bot: Botting) -> None:
     bot.Multibox.ResignParty()
     bot.Wait.ForMapLoad(target_map_id=643)
 
-    # --- Part 2: Fragment of Antiquities ---
+    # --- Part 2: Fragment of Antiquities objective ---
+    bot.States.AddCustomState(_anchor, "IAU:FRAGMENT_OF_ANTIQUITIES")
+    bot.Map.Travel(target_map_name="Sifhalla")
+    bot.Wait.ForMapLoad(target_map_id=643)
     bot.States.AddHeader("[Unlock] Fragment of Antiquities")
     bot.Move.XYAndExitMap(8832, 23870, target_map_id=513)
     bot.Wait.ForMapLoad(target_map_id=513)
 
-    bot.Move.XYAndDialog(-10926, 24732, 0x832901)  # Fragment of Antiquities
+    bot.Move.XY(*DRAKKAR_SIFHALLA_BLESSING_XY)
+    bot.States.AddCustomState(
+        lambda: _take_optional_blessing_at_xy(
+            DRAKKAR_SIFHALLA_BLESSING_XY,
+            0x84,
+            DRAKKAR_SIFHALLA_BLESSING_MODEL_ID,
+            "Drakkar Lake shrine outside Sifhalla",
+        ),
+        "Take Drakkar Lake blessing outside Sifhalla",
+    )
+
+    bot.Move.XY(-10926, 24732)
+    bot.States.AddCustomState(
+        lambda: _interact_outrunner_remlok(0x832901),
+        "Talk to Outrunner Remlok: enter the Sepulchre",
+    )
+
+    bot.Move.XY(*DRAKKAR_SEPULCHRE_BLESSING_XY)
+    bot.States.AddCustomState(
+        lambda: _take_optional_blessing_at_xy(
+            DRAKKAR_SEPULCHRE_BLESSING_XY,
+            0x84,
+            DRAKKAR_SEPULCHRE_BLESSING_MODEL_ID,
+            "Drakkar Lake shrine before Sepulchre",
+        ),
+        "Take Drakkar Lake blessing before Sepulchre",
+    )
     bot.Move.XYAndExitMap(-12138, 26829, target_map_id=628)
     bot.Wait.ForMapLoad(target_map_id=628)
 
-    bot.Move.XY(-5343, -15773)     # proof of strength
+    bot.Move.XY(*SEPULCHRE_LEVEL1_ENTRANCE_BLESSING_XY)
+    bot.States.AddCustomState(
+        lambda: _take_optional_blessing_at_xy(
+            SEPULCHRE_LEVEL1_ENTRANCE_BLESSING_XY,
+            0x84,
+            SEPULCHRE_LEVEL1_ENTRANCE_BLESSING_MODEL_ID,
+            "Sepulchre level 1 entrance blessing",
+        ),
+        "Take Sepulchre level 1 entrance blessing",
+    )
+
+    bot.Move.XY(-5366, -15794)     # walk over Proof of Strength to open matching gates
     bot.Move.XY(-6237, -9310)
     bot.Move.XY(-7512, -8414)
     bot.Move.XY(-12804, 1066)      # Defeat the Fragment of Antiquities
@@ -716,8 +1044,16 @@ def Unlock_i_am_unstoppable(bot: Botting) -> None:
     bot.Wait.ForTime(3000)
     bot.Wait.ForMapLoad(target_map_id=643)
 
-    bot.Move.XYAndDialog(14380, 23968, 0x833E07)   # Rewards
+    bot.States.AddCustomState(_anchor, "IAU:CLAIM_ANYTHING_YOU_CAN_DO")
+    bot.Map.Travel(target_map_name="Sifhalla")
+    bot.Wait.ForMapLoad(target_map_id=643)
+    bot.Move.XY(14380, 23968)
+    bot.States.AddCustomState(
+        lambda: _interact_sif_shadowhunter(0x833E07),
+        "Talk to Sif: claim Anything You Can Do reward",
+    )
     
+    bot.States.AddCustomState(_anchor, "IAU:COLD_AS_ICE")
     bot.Map.Travel(target_map_name="Sifhalla")
     bot.Wait.ForMapLoad(target_map_id=643)
 
@@ -777,8 +1113,15 @@ def Unlock_i_am_unstoppable(bot: Botting) -> None:
 
     bot.States.AddCustomState(_equip_skill_bar, "Equip Skill Bar")
 
-    bot.Move.XYAndDialog(14380, 23968, 0x834401)  # Cold As Ice (take quest)
-    bot.Dialogs.AtXY(14380, 23968, 0x85)          # I am Ready
+    bot.Move.XY(14380, 23968)
+    bot.States.AddCustomState(
+        lambda: _interact_sif_shadowhunter(0x834401),
+        "Talk to Sif: take Cold As Ice",
+    )
+    bot.States.AddCustomState(
+        lambda: _interact_sif_shadowhunter(0x85),
+        "Talk to Sif: I am ready",
+    )
 
     bot.Wait.ForMapLoad(target_map_id=690)        # Special Sifhalla Map
     bot.Wait.ForTime(5000)
@@ -794,7 +1137,14 @@ def Unlock_i_am_unstoppable(bot: Botting) -> None:
     bot.Wait.ForTime(20000)
     bot.Wait.ForMapLoad(target_map_id=643)
 
-    bot.Move.XYAndDialog(14380, 23968, 0x834407)  # Rewards
+    bot.States.AddCustomState(_anchor, "IAU:CLAIM_FINAL_REWARD")
+    bot.Map.Travel(target_map_name="Sifhalla")
+    bot.Wait.ForMapLoad(target_map_id=643)
+    bot.Move.XY(14380, 23968)
+    bot.States.AddCustomState(
+        lambda: _interact_sif_shadowhunter(0x834407),
+        "Talk to Sif: claim I Am Unstoppable reward",
+    )
     bot.States.JumpToStepName("MENU_IDLE")
 
 
@@ -1578,6 +1928,23 @@ SKILLS: List[Skill] = _build_skills() # type: ignore
 
 FACTIONS = ("Asura", "Vanguard", "Norn", "Deldrimor")
 
+ROUTE_CHECKPOINTS = [
+    (
+        '"I Am Unstoppable!"',
+        [
+            ("Start entire chain", "SKILL:Norn:i_am_unstoppable"),
+            ("Take Anything You Can Do", "IAU:TAKE_ANYTHING_YOU_CAN_DO"),
+            ("Hunt Avarr and Whiteout", "IAU:HUNT_AVARR_AND_WHITEOUT"),
+            ("Fragment of Antiquities", "IAU:FRAGMENT_OF_ANTIQUITIES"),
+            ("Claim Anything You Can Do", "IAU:CLAIM_ANYTHING_YOU_CAN_DO"),
+            ("Cold as Ice solo fight", "IAU:COLD_AS_ICE"),
+            ("Claim final reward", "IAU:CLAIM_FINAL_REWARD"),
+        ],
+    ),
+]
+_route_skill_index = 0
+_route_step_index = 0
+
 # -------------------------
 # MAIN ROUTINE: build FSM once (BDS style)
 # -------------------------
@@ -1613,18 +1980,39 @@ try:
     if HIDE_BDS_HEADER:
 
         def _draw_main_child_minimal(self, main_child_dimensions=(350, 275), icon_path="", iconwidth=96):
-            # --- Only keep Start/Stop toggle ---
-            icon = IconsFontAwesome5.ICON_STOP_CIRCLE
-            legend = "  Stop"
+            fsm = self._config.FSM
+            running = bool(self._config.fsm_running)
+            paused = bool(fsm.is_paused()) if running else False
 
-            if PyImGui.button(icon + legend + "##BotToggle"):
+            if running:
+                pause_label = "Resume" if paused else "Pause"
+                if PyImGui.button(f"{pause_label}##BotPauseResume"):
+                    if paused:
+                        fsm.resume()
+                        self._config.state_description = "Running"
+                        ConsoleLog(self._config.bot_name, "Script resumed", Console.MessageType.Info)
+                    else:
+                        fsm.pause()
+                        self._config.state_description = "Paused"
+                        try:
+                            stop_x, stop_y = Player.GetXY()
+                            Player.Move(stop_x, stop_y)
+                        except Exception:
+                            pass
+                        ConsoleLog(self._config.bot_name, "Script paused", Console.MessageType.Info)
+
+                PyImGui.same_line(0.0, 8.0)
+                if PyImGui.button("Stop##BotStop"):
                     self._config.fsm_running = False
                     ConsoleLog(self._config.bot_name, "Script stopped", Console.MessageType.Info)
                     self._config.state_description = "Idle"
-                    self._config.FSM.stop()
+                    fsm.stop()
                     GLOBAL_CACHE.Coroutines.clear()
 
-
+                PyImGui.text(f"Status: {'Paused' if paused else 'Running'}")
+                PyImGui.text_wrapped(f"Step: {fsm.get_current_step_name()}")
+            else:
+                PyImGui.text("Status: Idle - select a skill or checkpoint")
             PyImGui.dummy((0, 6))
 
         bot.UI._draw_main_child = types.MethodType(_draw_main_child_minimal, bot.UI)
@@ -1634,6 +2022,22 @@ except Exception:
 
 
 def draw_portal_ui():
+    global _route_skill_index, _route_step_index
+
+    PyImGui.text("Route Controls:")
+    route_labels = [route_label for route_label, _ in ROUTE_CHECKPOINTS]
+    _route_skill_index = PyImGui.combo("Route##SU_Route", _route_skill_index, route_labels)
+    checkpoints = ROUTE_CHECKPOINTS[_route_skill_index][1]
+    checkpoint_labels = [checkpoint_label for checkpoint_label, _ in checkpoints]
+    _route_step_index = max(0, min(_route_step_index, len(checkpoints) - 1))
+    _route_step_index = PyImGui.combo("Checkpoint##SU_Checkpoint", _route_step_index, checkpoint_labels)
+    if PyImGui.button("Jump to checkpoint##SU_JumpCheckpoint"):
+        _, checkpoint_state = checkpoints[_route_step_index]
+        _stop_clear_start_and_jump(checkpoint_state)
+    if _route_step_index > 0:
+        PyImGui.text_wrapped("Jumping ahead assumes all earlier quest objectives are already complete.")
+    PyImGui.separator()
+
     PyImGui.text("Select Skill:")
     PyImGui.separator()
 

--- a/Widgets/Automation/Bots/SkillsUnlocker/EOTN_SKILL_UNLOCKER.py
+++ b/Widgets/Automation/Bots/SkillsUnlocker/EOTN_SKILL_UNLOCKER.py
@@ -452,7 +452,7 @@ def UseTome21788AndBuyLichAura(bot, inv_cache) -> "Generator":
     yield from Routines.Yield.wait(300)
     ConsoleLog("Tome", "Done.")
 
-def _stop_clear_start_and_jump(step_name: str):
+def _stop_clear_start_and_jump(step_target: Any, step_name: Optional[str] = None):
     from Py4GWCoreLib.GlobalCache import GLOBAL_CACHE
 
     cfg = getattr(bot, "config", None)
@@ -489,10 +489,16 @@ def _stop_clear_start_and_jump(step_name: str):
         pass
 
     # ---- JUMP + START (ordering matters) ----
-    jumped = False
+    target_description = step_name or str(step_target)
+
+    def _jump_to_target() -> None:
+        if isinstance(step_target, int):
+            fsm.jump_to_state_by_step_number(step_target)
+        else:
+            fsm.jump_to_state_by_name(step_target)
+
     try:
-        fsm.jump_to_state_by_name(step_name)
-        jumped = True
+        _jump_to_target()
     except Exception as e:
         _log(f"[RUN] jump failed: {e}", PySystem.Console.MessageType.Error)
         return
@@ -516,11 +522,11 @@ def _stop_clear_start_and_jump(step_name: str):
         except Exception:
             pass
         try:
-            fsm.jump_to_state_by_name(step_name)
+            _jump_to_target()
         except Exception:
             pass
 
-    _log(f"[RUN] stop/clear -> jump -> start : {step_name}", PySystem.Console.MessageType.Warning)
+    _log(f"[RUN] stop/clear -> jump -> start : {target_description}", PySystem.Console.MessageType.Warning)
 
 # Anchor step (jumpable)
 _INIT_DONE = False
@@ -1928,22 +1934,64 @@ SKILLS: List[Skill] = _build_skills() # type: ignore
 
 FACTIONS = ("Asura", "Vanguard", "Norn", "Deldrimor")
 
-ROUTE_CHECKPOINTS = [
-    (
-        '"I Am Unstoppable!"',
-        [
-            ("Start entire chain", "SKILL:Norn:i_am_unstoppable"),
-            ("Take Anything You Can Do", "IAU:TAKE_ANYTHING_YOU_CAN_DO"),
-            ("Hunt Avarr and Whiteout", "IAU:HUNT_AVARR_AND_WHITEOUT"),
-            ("Fragment of Antiquities", "IAU:FRAGMENT_OF_ANTIQUITIES"),
-            ("Claim Anything You Can Do", "IAU:CLAIM_ANYTHING_YOU_CAN_DO"),
-            ("Cold as Ice solo fight", "IAU:COLD_AS_ICE"),
-            ("Claim final reward", "IAU:CLAIM_FINAL_REWARD"),
-        ],
-    ),
-]
+CHECKPOINT_LABEL_OVERRIDES = {
+    "IAU:TAKE_ANYTHING_YOU_CAN_DO": "Take Anything You Can Do",
+    "IAU:HUNT_AVARR_AND_WHITEOUT": "Hunt Avarr and Whiteout",
+    "IAU:FRAGMENT_OF_ANTIQUITIES": "Fragment of Antiquities",
+    "IAU:CLAIM_ANYTHING_YOU_CAN_DO": "Claim Anything You Can Do",
+    "IAU:COLD_AS_ICE": "Cold as Ice solo fight",
+    "IAU:CLAIM_FINAL_REWARD": "Claim final reward",
+}
 _route_skill_index = 0
 _route_step_index = 0
+_route_previous_skill_index = -1
+
+
+def _get_route_checkpoints():
+    """Expose every non-header FSM state, grouped by its owning skill route."""
+    cfg = getattr(bot, "config", None)
+    fsm = getattr(cfg, "FSM", None) if cfg else None
+    state_names = fsm.get_state_names() if fsm else []
+    if not state_names:
+        return []
+
+    anchor_positions = {}
+    for _, _, _, step_name, _, _ in SKILLS:
+        try:
+            anchor_positions[step_name] = state_names.index(step_name)
+        except ValueError:
+            continue
+
+    routes = []
+    ordered_anchors = [
+        (skill, anchor_positions[skill[3]])
+        for skill in SKILLS
+        if skill[3] in anchor_positions
+    ]
+    for route_number, (skill, start_index) in enumerate(ordered_anchors):
+        _, label, faction, step_name, _, _ = skill
+        end_index = (
+            ordered_anchors[route_number + 1][1]
+            if route_number + 1 < len(ordered_anchors)
+            else len(state_names)
+        )
+
+        checkpoints = []
+        visible_step = 0
+        for state_index in range(start_index, end_index):
+            state_name = state_names[state_index]
+            if state_name.startswith("[H]"):
+                continue
+            visible_step += 1
+            if state_name == step_name:
+                display_name = "Start entire route"
+            else:
+                display_name = CHECKPOINT_LABEL_OVERRIDES.get(state_name, state_name)
+            checkpoints.append((f"{visible_step}. {display_name}", state_index, state_name))
+
+        if checkpoints:
+            routes.append((f"[{faction}] {label}", checkpoints))
+    return routes
 
 # -------------------------
 # MAIN ROUTINE: build FSM once (BDS style)
@@ -2022,18 +2070,28 @@ except Exception:
 
 
 def draw_portal_ui():
-    global _route_skill_index, _route_step_index
+    global _route_skill_index, _route_step_index, _route_previous_skill_index
 
     PyImGui.text("Route Controls:")
-    route_labels = [route_label for route_label, _ in ROUTE_CHECKPOINTS]
+    route_checkpoints = _get_route_checkpoints()
+    if not route_checkpoints:
+        PyImGui.text_wrapped("Route steps are still being prepared. Please reopen this panel in a moment.")
+        return
+
+    route_labels = [route_label for route_label, _ in route_checkpoints]
+    _route_skill_index = max(0, min(_route_skill_index, len(route_checkpoints) - 1))
     _route_skill_index = PyImGui.combo("Route##SU_Route", _route_skill_index, route_labels)
-    checkpoints = ROUTE_CHECKPOINTS[_route_skill_index][1]
-    checkpoint_labels = [checkpoint_label for checkpoint_label, _ in checkpoints]
+    if _route_skill_index != _route_previous_skill_index:
+        _route_step_index = 0
+        _route_previous_skill_index = _route_skill_index
+
+    checkpoints = route_checkpoints[_route_skill_index][1]
+    checkpoint_labels = [checkpoint_label for checkpoint_label, _, _ in checkpoints]
     _route_step_index = max(0, min(_route_step_index, len(checkpoints) - 1))
     _route_step_index = PyImGui.combo("Checkpoint##SU_Checkpoint", _route_step_index, checkpoint_labels)
     if PyImGui.button("Jump to checkpoint##SU_JumpCheckpoint"):
-        _, checkpoint_state = checkpoints[_route_step_index]
-        _stop_clear_start_and_jump(checkpoint_state)
+        _, checkpoint_index, checkpoint_state = checkpoints[_route_step_index]
+        _stop_clear_start_and_jump(checkpoint_index, checkpoint_state)
     if _route_step_index > 0:
         PyImGui.text_wrapped("Jumping ahead assumes all earlier quest objectives are already complete.")
     PyImGui.separator()


### PR DESCRIPTION
## Summary
- make Skills Unlocker discoverable in the widget browser
- fix `You Move Like a Dwarf!` by starting from Sifhalla and resolving Sif Shadowhunter from the complete live-agent array for quest acceptance and rewards
- fix the `I Am Unstoppable!` chain by reliably taking prerequisite quests, resolving Outrunner Remlok live, crossing the Proof of Strength, and adding restartable checkpoints
- expose the checkpoint selector for every registered skill route, deriving jump targets from each route's live FSM states instead of maintaining an IAU-only list
- keep HeroAI active after NPC dialogs and recover dead party members before route progression resumes
- improve Paragon HeroAI handling for Heroic Refrain and party-dependent support skills
- add file-backed runtime diagnostics for agent-interaction failures

## Validation
- in-memory Python compilation passed for every changed Python file
- `git diff --check` passed
- tested interactively in PY4GW Clean Test while diagnosing YMLAD and IAU progression
- checkpoint jumping has been runtime-tested on `I Am Unstoppable!`; the same index-based selector is now exposed for the other skill routes but has not yet been runtime-tested on each of them
- no dedicated Skills Unlocker automated tests currently exist in the repository
