### PR TITLE
Fix HeroAI targeting for Symbol of Wrath

### DIFF
--- a/HeroAI/custom_skill_src/monk.py
+++ b/HeroAI/custom_skill_src/monk.py
@@ -1040,7 +1040,7 @@ class MonkSkills:
         skill = CustomSkill()
         skill.SkillID = GLOBAL_CACHE.Skill.GetID("Symbol_of_Wrath")
         skill.SkillType = SkillType.Spell.value
-        skill.TargetAllegiance = Skilltarget.Self.value
+        skill.TargetAllegiance = Skilltarget.Enemy.value
         skill.Nature = SkillNature.Offensive.value
         skill_data[skill.SkillID] = skill
 


### PR DESCRIPTION
## Summary
- Change Symbol of Wrath's HeroAI target allegiance from Self to Enemy.
- Align automatic targeting with the updated skill behavior at the target foe's location.

## Validation
- Python syntax parse passed.
- Git diff check passed.
- Verified in-client in the PY4GW Clean Test checkout; Symbol of Wrath now casts successfully on foes.