### PR TITLE
Improve HeroAI Paragon refrain rotation

### DIFF
--- a/Py4GWCoreLib/Builds/Paragon/P_W/Defensive Refrain.py
+++ b/Py4GWCoreLib/Builds/Paragon/P_W/Defensive Refrain.py
@@ -6,9 +6,12 @@ from Py4GWCoreLib.Skill import Skill
 from Py4GWCoreLib.Builds.Skills import SkillsTemplate
 
 Heroic_Refrain_ID = Skill.GetID("Heroic_Refrain")
+Anthem_of_Flame_ID = Skill.GetID("Anthem_of_Flame")
 Theyre_on_Fire_ID = Skill.GetID("Theyre_on_Fire")
+Mending_Refrain_ID = Skill.GetID("Mending_Refrain")
 Hasty_Refrain_ID = Skill.GetID("Hasty_Refrain")
 Aggressive_Refrain_ID = Skill.GetID("Aggressive_Refrain")
+Mighty_Throw_ID = Skill.GetID("Mighty_Throw")
 Stand_Your_Ground_ID = Skill.GetID("Stand_Your_Ground")
 For_Great_Justice_ID = Skill.GetID("For_Great_Justice")
 Theres_Nothing_to_Fear_ID = Skill.GetID("Theres_Nothing_to_Fear")
@@ -39,9 +42,12 @@ class Paragon_Refrain(BuildMgr):
             optional_skills=[
                 Save_Yourselves_luxon_ID,
                 Save_Yourselves_kurzick_ID,
+                Anthem_of_Flame_ID,
+                Mending_Refrain_ID,
                 Hasty_Refrain_ID,
                 Never_Surrender_ID,
                 Aggressive_Refrain_ID,
+                Mighty_Throw_ID,
                 Stand_Your_Ground_ID,
                 For_Great_Justice_ID,
                 Blazing_Finale_ID,
@@ -69,6 +75,18 @@ class Paragon_Refrain(BuildMgr):
         if self.IsSkillEquipped(Heroic_Refrain_ID) and (yield from self.skills.Paragon.Leadership.Heroic_Refrain()):
             return True
 
+        if self.IsSkillEquipped(Mending_Refrain_ID) and (yield from self.skills.Paragon.Motivation.Mending_Refrain()):
+            return True
+
+        if self.IsSkillEquipped(Hasty_Refrain_ID) and (yield from self.skills.Paragon.Motivation.Hasty_Refrain()):
+            return True
+
+        if self.IsSkillEquipped(Aggressive_Refrain_ID) and (yield from self.skills.Paragon.Leadership.Aggressive_Refrain()):
+            return True
+
+        if self.IsSkillEquipped(Anthem_of_Flame_ID) and (yield from self.skills.Paragon.Leadership.Anthem_of_Flame()):
+            return True
+
         if self.IsSkillEquipped(Theyre_on_Fire_ID) and (yield from self.skills.Paragon.Leadership.Theyre_on_Fire()):
             return True
 
@@ -78,10 +96,13 @@ class Paragon_Refrain(BuildMgr):
         if self.IsSkillEquipped(Angelic_Protection_ID) and (yield from self.skills.Paragon.Leadership.Angelic_Protection(health_threshold=0.30)):
             return True
 
-        if self.IsSkillEquipped(Theres_Nothing_to_Fear_ID) and (yield from self.skills.Any.NoAttribute.Theres_Nothing_to_Fear()):
+        if self.IsSkillEquipped(Save_Yourselves_luxon_ID) and (yield from self.skills.Any.NoAttribute.Save_Yourselves_luxon()):
             return True
 
-        if self.IsSkillEquipped(Aggressive_Refrain_ID) and (yield from self.skills.Paragon.Leadership.Aggressive_Refrain()):
+        if self.IsSkillEquipped(Save_Yourselves_kurzick_ID) and (yield from self.skills.Any.NoAttribute.Save_Yourselves_kurzick()):
+            return True
+
+        if self.IsSkillEquipped(Theres_Nothing_to_Fear_ID) and (yield from self.skills.Any.NoAttribute.Theres_Nothing_to_Fear()):
             return True
 
         if self.IsSkillEquipped(For_Great_Justice_ID) and (yield from self.skills.Warrior.NoAttribute.For_Great_Justice()):
@@ -90,19 +111,10 @@ class Paragon_Refrain(BuildMgr):
         if self.IsSkillEquipped(Make_Your_Time_ID) and (yield from self.skills.Paragon.Leadership.Make_Your_Time()):
             return True
 
-        if self.IsSkillEquipped(Save_Yourselves_luxon_ID) and (yield from self.skills.Any.NoAttribute.Save_Yourselves_luxon()):
-            return True
-
-        if self.IsSkillEquipped(Save_Yourselves_kurzick_ID) and (yield from self.skills.Any.NoAttribute.Save_Yourselves_kurzick()):
-            return True
-
         if self.IsSkillEquipped(Stand_Your_Ground_ID) and (yield from self.skills.Paragon.Command.Stand_Your_Ground()):
             return True
 
         if self.IsSkillEquipped(Cant_Touch_This_ID) and (yield from self.skills.Paragon.Command.Cant_Touch_This()):
-            return True
-
-        if self.IsSkillEquipped(Hasty_Refrain_ID) and (yield from self.skills.Paragon.Motivation.Hasty_Refrain()):
             return True
 
         if self.IsSkillEquipped(Never_Surrender_ID) and (yield from self.skills.Paragon.Motivation.Never_Surrender()):
@@ -118,6 +130,9 @@ class Paragon_Refrain(BuildMgr):
             return True
 
         if self.IsSkillEquipped(Ebon_Battle_Standard_of_Wisdom_ID) and (yield from self.skills.Any.NoAttribute.Ebon_Battle_Standard_of_Wisdom()):
+            return True
+
+        if self.IsSkillEquipped(Mighty_Throw_ID) and (yield from self.skills.Paragon.SpearMastery.Mighty_Throw()):
             return True
 
         if (yield from self.AutoAttack()):

--- a/Py4GWCoreLib/Builds/Skills/paragon/Leadership.py
+++ b/Py4GWCoreLib/Builds/Skills/paragon/Leadership.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from Py4GWCoreLib.BuildMgr import BuildCoroutine
-from Py4GWCoreLib import Player, Routines
+from Py4GWCoreLib import GLOBAL_CACHE, Player, Routines
 from Py4GWCoreLib.Skill import Skill
 
 if TYPE_CHECKING:
@@ -24,6 +24,31 @@ class Leadership:
         leadership = next((attribute for attribute in attributes if attribute.GetName() == "Leadership"), None)
         return int(getattr(leadership, "level", 0) or 0)
 
+    @staticmethod
+    def _get_effect_attribute_level(skill_id: int) -> int:
+        player_agent_id = Player.GetAgentID()
+        effect = next(
+            (
+                item
+                for item in GLOBAL_CACHE.Effects.GetEffects(player_agent_id)
+                if item.skill_id == skill_id
+            ),
+            None,
+        )
+        return int(getattr(effect, "attribute_level", 0) or 0)
+
+    def _heroic_refrain_needs_self_bootstrap(self, heroic_refrain_id: int) -> bool:
+        player_agent_id = Player.GetAgentID()
+        if not Routines.Checks.Agents.HasEffect(player_agent_id, heroic_refrain_id):
+            return True
+
+        leadership_level = self._get_leadership_level()
+        if leadership_level >= 20:
+            return False
+
+        cast_level = self._get_effect_attribute_level(heroic_refrain_id)
+        return cast_level > 0 and leadership_level > cast_level
+
     #region H
     def Heroic_Refrain(self) -> BuildCoroutine:
         heroic_refrain_id: int = Skill.GetID("Heroic_Refrain")
@@ -33,7 +58,7 @@ class Leadership:
             return False
 
         player_agent_id = Player.GetAgentID()
-        if self._get_leadership_level() < 20:
+        if self._heroic_refrain_needs_self_bootstrap(heroic_refrain_id):
             return (yield from self.build.CastSkillIDAndRestoreTarget(
                 skill_id=heroic_refrain_id,
                 target_agent_id=player_agent_id,
@@ -64,13 +89,27 @@ class Leadership:
     #endregion
 
     #region A
+    def Anthem_of_Flame(self) -> BuildCoroutine:
+        anthem_of_flame_id: int = Skill.GetID("Anthem_of_Flame")
+        player_agent_id = Player.GetAgentID()
+
+        if not self.build.IsSkillEquipped(anthem_of_flame_id):
+            return False
+        if Routines.Checks.Agents.HasEffect(player_agent_id, anthem_of_flame_id):
+            return False
+
+        return (yield from self.build.CastSkillID(
+            skill_id=anthem_of_flame_id,
+            target_agent_id=player_agent_id,
+            log=False,
+            aftercast_delay=250,
+        ))
+
     def Aggressive_Refrain(self) -> BuildCoroutine:
         aggressive_refrain_id: int = Skill.GetID("Aggressive_Refrain")
         player_agent_id = Player.GetAgentID()
 
         if not self.build.IsSkillEquipped(aggressive_refrain_id):
-            return False
-        if not (self.build.IsInAggro() or self.build.IsCloseToAggro()):
             return False
         if Routines.Checks.Agents.HasEffect(player_agent_id, aggressive_refrain_id):
             return False

--- a/Py4GWCoreLib/Builds/Skills/paragon/Motivation.py
+++ b/Py4GWCoreLib/Builds/Skills/paragon/Motivation.py
@@ -62,6 +62,29 @@ class Motivation:
         ))
     #endregion
 
+    #region M
+    def Mending_Refrain(self) -> BuildCoroutine:
+        mending_refrain_id: int = Skill.GetID("Mending_Refrain")
+        mending_refrain = self.build.GetCustomSkill(mending_refrain_id)
+
+        if not self.build.IsSkillEquipped(mending_refrain_id):
+            return False
+
+        target_agent_id = self.build.ResolveAllyTarget(
+            mending_refrain_id,
+            mending_refrain,
+        )
+        if not target_agent_id:
+            return False
+
+        return (yield from self.build.CastSkillIDAndRestoreTarget(
+            skill_id=mending_refrain_id,
+            target_agent_id=target_agent_id,
+            log=False,
+            aftercast_delay=250,
+        ))
+    #endregion
+
     #region N
     def Never_Surrender(self) -> BuildCoroutine:
         from HeroAI.targeting import GetAllAlliesArray

--- a/Py4GWCoreLib/Builds/Skills/paragon/SpearMastery.py
+++ b/Py4GWCoreLib/Builds/Skills/paragon/SpearMastery.py
@@ -2,10 +2,39 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from Py4GWCoreLib.BuildMgr import BuildCoroutine
+from Py4GWCoreLib.Skill import Skill
+
 if TYPE_CHECKING:
     from Py4GWCoreLib.BuildMgr import BuildMgr
+
+__all__ = ["SpearMastery"]
+
 
 class SpearMastery:
     def __init__(self, build: BuildMgr) -> None:
         self.build: BuildMgr = build
+
+    def _resolve_spear_target(self, skill_id: int) -> int:
+        if not self.build.CanCastSkillID(skill_id):
+            return 0
+        target_acquired, _ = self.build._resolve_target("EnemyInjured")
+        if not target_acquired:
+            return 0
+        return self.build.current_target_id
+
+    #region M
+    def Mighty_Throw(self) -> BuildCoroutine:
+        mighty_throw_id: int = Skill.GetID("Mighty_Throw")
+        target_agent_id = self._resolve_spear_target(mighty_throw_id)
+        if not target_agent_id:
+            return False
+
+        return (yield from self.build.CastSkillIDAndRestoreTarget(
+            skill_id=mighty_throw_id,
+            target_agent_id=target_agent_id,
+            log=False,
+            aftercast_delay=250,
+        ))
+    #endregion
 


### PR DESCRIPTION
## Summary
- bootstrap Heroic Refrain safely, then distribute Heroic, Mending, and Hasty Refrain before maintenance shouts
- maintain Aggressive Refrain and support Anthem of Flame as an upkeep chant
- prioritize party protection shouts and activate For Great Justice before Mighty Throw
- add specialized Mending Refrain and Mighty Throw handlers to the Defensive Refrain contract

## Validation
- tested in-client with a 16 Leadership Heroic Refrain Paragon
- confirmed the 16 -> 19 -> 20 self-bootstrap and party distribution
- confirmed Hasty Refrain distribution after restarting the updated contract
- Python syntax checks passed for all four modified modules
- git diff --check passed