### PR TITLE
Improve combat-event compatibility and interrupt timing

### DIFF
--- a/HeroAI/interrupt.py
+++ b/HeroAI/interrupt.py
@@ -566,8 +566,18 @@ def _queue_outcome(target_id: int, enemy_skill_id: int, our_skill_id: int) -> No
         enemy_total_s = GLOBAL_CACHE.Skill.Data.GetActivation(enemy_skill_id) or 0.0
     except Exception:
         enemy_total_s = 0.0
+    enemy_total_ms = int(enemy_total_s * 1000)
+    try:
+        from Py4GWCoreLib.Builds.Skills import ReforgedSupport
+        native_total_ms = int(
+            ReforgedSupport.get_cast_duration_ms(target_id, enemy_skill_id) or 0
+        )
+        if native_total_ms > 0:
+            enemy_total_ms = native_total_ms
+    except Exception:
+        pass
     cast_observer.queue_outcome(
-        target_id, enemy_skill_id, our_skill_id, int(enemy_total_s * 1000)
+        target_id, enemy_skill_id, our_skill_id, enemy_total_ms
     )
 
 
@@ -647,7 +657,28 @@ def is_interrupt_feasible(
 
     # --- Elapsed / remaining (from sampler) ---
     elapsed_ms = cast_observer.elapsed_ms(target_agent_id, enemy_skill_id) or 0
+    try:
+        from Py4GWCoreLib.Builds.Skills import ReforgedSupport
+        native_elapsed_ms = ReforgedSupport.get_observed_cast_elapsed_ms(
+            target_agent_id, enemy_skill_id
+        )
+        if native_elapsed_ms is not None:
+            elapsed_ms = max(0, int(native_elapsed_ms))
+    except Exception:
+        pass
     enemy_total_ms = int(enemy_total_s * 1000)
+    # Reforged CASTTIME packets contain the real duration after Fast Casting
+    # and cast-time modifiers. Prefer that exact value when the event bridge
+    # captured it; skill data remains the safe fallback.
+    try:
+        from Py4GWCoreLib.Builds.Skills import ReforgedSupport
+        native_total_ms = int(
+            ReforgedSupport.get_cast_duration_ms(target_agent_id, enemy_skill_id) or 0
+        )
+        if native_total_ms > 0:
+            enemy_total_ms = native_total_ms
+    except Exception:
+        pass
     remaining_ms = max(0, enemy_total_ms - elapsed_ms)
 
     # --- Our activation: branch on skill type ---

--- a/Py4GWCoreLib/Builds/Skills/ReforgedSupport.py
+++ b/Py4GWCoreLib/Builds/Skills/ReforgedSupport.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+"""Reforged native combat-event bridge with safe polling fallbacks.
+
+Native PyAgentEvents timestamps are preferred for cast starts, exact CASTTIME
+packets are retained when available, and live Agent state remains the final
+truth before an interrupt is fired.
+"""
+
+import math
+from collections import deque
+
+_CASTS: dict[int, tuple[int, int, int]] = {}          # caster -> skill,target,start
+_CAST_DURATIONS_MS: dict[tuple[int, int], int] = {}  # (caster,skill) -> exact total
+_PENDING_CASTTIME: dict[int, tuple[int, int]] = {}   # caster -> duration,tick
+_OUTCOMES: deque[tuple[int, int, int, str]] = deque(maxlen=512)
+_DAMAGE: deque[tuple[int, int, int, float, int]] = deque(maxlen=1024)
+ENABLE_DAMAGE_EVENTS = False  # stability-first: cast events only in production
+_REGISTERED = False
+_INIT_ERROR = ""
+_EVENT_COUNT = 0
+_PATH_CACHE: dict[tuple[int, int, int, int, int], tuple[int, bool, float]] = {}
+_PATH_CACHE_TTL_MS = 1200
+
+
+def _tick() -> int:
+    try:
+        import PySystem
+        return int(PySystem.get_tick_count64() or 0)
+    except Exception:
+        try:
+            import Py4GW
+            return int(Py4GW.Game.get_tick_count64() or 0)
+        except Exception:
+            return 0
+
+
+def _on_skill_activated(caster_id: int, skill_id: int, target_id: int, event_tick: int = 0) -> None:
+    """Record the earliest packet for a cast and avoid duplicate timestamp reset."""
+    global _EVENT_COUNT
+    caster_id, skill_id = int(caster_id or 0), int(skill_id or 0)
+    if caster_id <= 0 or skill_id <= 0:
+        return
+
+    now = int(event_tick or _tick())
+    target_id = int(target_id or 0)
+    active = _CASTS.get(caster_id)
+    if active and int(active[0]) == skill_id:
+        old_skill, old_target, old_start = active
+        _CASTS[caster_id] = (
+            int(old_skill),
+            target_id or int(old_target),
+            min(int(old_start or now), int(now or old_start)),
+        )
+    else:
+        if active:
+            _CAST_DURATIONS_MS.pop((caster_id, int(active[0])), None)
+        _CASTS[caster_id] = (skill_id, target_id, now)
+
+    pending = _PENDING_CASTTIME.pop(caster_id, None)
+    if pending:
+        duration_ms, captured_tick = pending
+        if not now or not captured_tick or now - captured_tick <= 750:
+            _CAST_DURATIONS_MS[(caster_id, skill_id)] = int(duration_ms)
+    _EVENT_COUNT += 1
+
+
+def _on_cast_time(caster_id: int, skill_id: int, duration_seconds: float) -> None:
+    """Capture the exact native cast duration, including cast-time modifiers."""
+    global _EVENT_COUNT
+    caster_id, skill_id = int(caster_id or 0), int(skill_id or 0)
+    try:
+        duration_ms = int(float(duration_seconds or 0.0) * 1000.0)
+    except Exception:
+        duration_ms = 0
+    if caster_id <= 0 or duration_ms <= 0:
+        return
+
+    active = _CASTS.get(caster_id)
+    if skill_id <= 0 and active:
+        skill_id = int(active[0])
+    if skill_id > 0:
+        _CAST_DURATIONS_MS[(caster_id, skill_id)] = duration_ms
+    else:
+        _PENDING_CASTTIME[caster_id] = (duration_ms, _tick())
+    _EVENT_COUNT += 1
+
+
+def _finish(caster_id: int, skill_id: int, outcome: str) -> None:
+    global _EVENT_COUNT
+    caster_id, skill_id = int(caster_id or 0), int(skill_id or 0)
+    active = _CASTS.get(caster_id)
+    if skill_id <= 0 and active:
+        skill_id = int(active[0])
+    if active is None or skill_id <= 0 or int(active[0]) == skill_id:
+        _CASTS.pop(caster_id, None)
+    if caster_id > 0 and skill_id > 0:
+        _CAST_DURATIONS_MS.pop((caster_id, skill_id), None)
+    _PENDING_CASTTIME.pop(caster_id, None)
+    _OUTCOMES.append((_tick(), caster_id, skill_id, str(outcome)))
+    _EVENT_COUNT += 1
+
+
+def _on_skill_finished(caster_id: int, skill_id: int) -> None:
+    _finish(caster_id, skill_id, "finished")
+
+
+def _on_skill_stopped(caster_id: int, skill_id: int) -> None:
+    _finish(caster_id, skill_id, "stopped")
+
+
+def _on_skill_interrupted(caster_id: int, skill_id: int) -> None:
+    _finish(caster_id, skill_id, "interrupted")
+
+
+def _on_damage(target_id: int, source_id: int, damage_fraction: float, skill_id: int) -> None:
+    global _EVENT_COUNT
+    _DAMAGE.append((
+        _tick(), int(target_id or 0), int(source_id or 0),
+        float(damage_fraction or 0.0), int(skill_id or 0),
+    ))
+    _EVENT_COUNT += 1
+
+
+def ensure_initialized() -> bool:
+    global _REGISTERED, _INIT_ERROR
+    if _REGISTERED:
+        return True
+    try:
+        from Py4GWCoreLib.CombatEvents import CombatEvents, CombatEventQueue
+        if not CombatEventQueue.IsAvailable():
+            _INIT_ERROR = "native event backend unavailable; using frame observer/polling fallback"
+            return False
+        if not CombatEvents.Enable():
+            _INIT_ERROR = "native event backend could not initialize; using fallback"
+            return False
+        if hasattr(CombatEvents, "OnSkillActivatedTimed"):
+            CombatEvents.OnSkillActivatedTimed(_on_skill_activated)
+        else:
+            CombatEvents.OnSkillActivated(_on_skill_activated)
+        CombatEvents.OnCastTime(_on_cast_time)
+        CombatEvents.OnSkillFinished(_on_skill_finished)
+        CombatEvents.OnSkillStopped(_on_skill_stopped)
+        CombatEvents.OnSkillInterrupted(_on_skill_interrupted)
+        if ENABLE_DAMAGE_EVENTS:
+            CombatEvents.OnDamage(_on_damage)
+        _REGISTERED = True
+        _INIT_ERROR = ""
+        try:
+            import PySystem
+            PySystem.Console.Log(
+                "HeroAI Events",
+                f"Cast event bridge active via {CombatEventQueue.GetBackendName()}",
+                PySystem.Console.MessageType.Info,
+            )
+        except Exception:
+            pass
+        return True
+    except Exception as exc:
+        _INIT_ERROR = repr(exc)
+        return False
+
+
+def get_active_casts(max_age_ms: int = 8000) -> tuple[tuple[int, int, int, int, str], ...]:
+    ensure_initialized()
+    now = _tick()
+    out: list[tuple[int, int, int, int, str]] = []
+    for caster_id, (skill_id, target_id, start_tick) in list(_CASTS.items()):
+        if now and start_tick and now - start_tick > int(max_age_ms):
+            _CASTS.pop(caster_id, None)
+            _CAST_DURATIONS_MS.pop((int(caster_id), int(skill_id)), None)
+            continue
+        out.append((int(caster_id), int(skill_id), int(target_id), int(start_tick), "native_event"))
+    out.sort(key=lambda item: (item[3], item[0], item[1]))
+    return tuple(out)
+
+
+def get_recent_cast(caster_id: int, max_age_ms: int = 8000) -> tuple[int, int, int, float] | None:
+    caster_id = int(caster_id or 0)
+    for aid, sid, target, start, _ in reversed(get_active_casts(max_age_ms=max_age_ms)):
+        if aid == caster_id:
+            duration_s = float(_CAST_DURATIONS_MS.get((aid, sid), 0)) / 1000.0
+            return (sid, target, start, duration_s)
+    return None
+
+
+def get_cast_target_id(caster_id: int, expected_skill_id: int = 0) -> int:
+    cast = get_recent_cast(caster_id)
+    if not cast:
+        return 0
+    skill_id, target_id, _, _ = cast
+    if expected_skill_id and int(skill_id) != int(expected_skill_id):
+        return 0
+    return int(target_id or 0)
+
+
+def get_cast_duration_ms(caster_id: int, skill_id: int) -> int:
+    """Return exact native CASTTIME for the active cast, or zero if unknown."""
+    ensure_initialized()
+    return max(0, int(_CAST_DURATIONS_MS.get((int(caster_id), int(skill_id)), 0) or 0))
+
+
+def get_cast_outcome(caster_id: int, skill_id: int, since_tick: int) -> str | None:
+    ensure_initialized()
+    caster_id, skill_id, since_tick = int(caster_id or 0), int(skill_id or 0), int(since_tick or 0)
+    for ts, aid, sid, result in reversed(_OUTCOMES):
+        if ts < since_tick:
+            break
+        if aid == caster_id and (skill_id <= 0 or sid in (0, skill_id)):
+            return result
+    return None
+
+
+
+def get_recent_cast_outcomes(max_age_ms: int = 8000) -> tuple[tuple[int, int, int, str], ...]:
+    """Return recent cast finish/stop/interrupt events without damage hooks.
+
+    This is safe for threat learning and Mistrust/interrupt diagnostics.  It
+    intentionally exposes only compact immutable tuples and never dereferences
+    combat agents from inside the native callback.
+    """
+    ensure_initialized()
+    now = _tick()
+    out: list[tuple[int, int, int, str]] = []
+    for item in reversed(_OUTCOMES):
+        ts = int(item[0])
+        if now and ts and now - ts > int(max_age_ms):
+            break
+        out.append((ts, int(item[1]), int(item[2]), str(item[3])))
+    out.reverse()
+    return tuple(out)
+
+def get_recent_damage_events(max_age_ms: int = 2000) -> tuple[tuple[int, int, int, float, int], ...]:
+    ensure_initialized()
+    now = _tick()
+    out = []
+    for item in reversed(_DAMAGE):
+        ts = int(item[0])
+        if now and ts and now - ts > int(max_age_ms):
+            break
+        out.append(item)
+    out.reverse()
+    return tuple(out)
+
+
+def get_observed_cast_elapsed_ms(agent_id: int, skill_id: int) -> int | None:
+    now = _tick()
+    for caster_id, observed_skill_id, _, start_tick, _ in reversed(get_active_casts()):
+        if caster_id == int(agent_id) and observed_skill_id == int(skill_id):
+            return max(0, now - int(start_tick)) if now and start_tick else 0
+    try:
+        from HeroAI.interrupt import cast_observer
+        observed = cast_observer.elapsed_ms(int(agent_id), int(skill_id))
+        return None if observed is None else max(0, int(observed))
+    except Exception:
+        return None
+
+
+def get_cast_source(agent_id: int, skill_id: int) -> str:
+    for caster_id, observed_skill_id, _, _, source in reversed(get_active_casts()):
+        if caster_id == int(agent_id) and observed_skill_id == int(skill_id):
+            return source
+    try:
+        from HeroAI.interrupt import cast_observer
+        if cast_observer.elapsed_ms(int(agent_id), int(skill_id)) is not None:
+            return "frame_observer"
+    except Exception:
+        pass
+    return "polling_fallback"
+
+
+def get_cast_start_tick(agent_id: int, skill_id: int) -> int:
+    for caster_id, observed_skill_id, _, start_tick, _ in reversed(get_active_casts()):
+        if caster_id == int(agent_id) and observed_skill_id == int(skill_id):
+            return int(start_tick or 0)
+    return 0
+
+
+def raw_event_status() -> dict[str, int | bool | str]:
+    initialized = ensure_initialized()
+    queue_size = 0
+    backend = "unavailable"
+    try:
+        from Py4GWCoreLib.CombatEvents import CombatEventQueue
+        queue_size = int(CombatEventQueue.GetQueueSize() or 0)
+        backend = str(CombatEventQueue.GetBackendName())
+    except Exception:
+        pass
+    return {
+        "initialized": bool(initialized),
+        "backend": backend,
+        "queue_size": queue_size,
+        "native_events": int(_EVENT_COUNT),
+        "active_casts": len(_CASTS),
+        "exact_casttimes": len(_CAST_DURATIONS_MS),
+        "damage_events_enabled": bool(ENABLE_DAMAGE_EVENTS),
+        "damage_events": len(_DAMAGE),
+        "error": _INIT_ERROR,
+    }
+
+
+def path_quality(start: tuple[float, float], goal: tuple[float, float]) -> tuple[bool, float]:
+    """Optional Reforged path validation retained for non-movement callers."""
+    now = _tick()
+    try:
+        from Py4GWCoreLib.Agent import Agent
+        from Py4GWCoreLib.Player import Player
+        z = float(Agent.GetZPlane(Player.GetAgentID()) or 0.0)
+    except Exception:
+        z = 0.0
+    key = (round(start[0] / 40), round(start[1] / 40), round(goal[0] / 40), round(goal[1] / 40), int(z))
+    cached = _PATH_CACHE.get(key)
+    if cached and (not now or now - cached[0] <= _PATH_CACHE_TTL_MS):
+        return cached[1], cached[2]
+    try:
+        import PyPathing
+        planner = PyPathing.PathPlanner()
+        path = list(planner.compute_immediate(float(start[0]), float(start[1]), z, float(goal[0]), float(goal[1]), z) or [])
+        if not path:
+            result = (False, float("inf"))
+        else:
+            length = 0.0
+            px, py = float(start[0]), float(start[1])
+            for point in path:
+                x, y = float(point[0]), float(point[1])
+                length += math.hypot(x - px, y - py)
+                px, py = x, y
+            endpoint_error = math.hypot(px - float(goal[0]), py - float(goal[1]))
+            result = (endpoint_error <= 220.0, length + endpoint_error)
+    except Exception:
+        result = (False, float("inf"))
+    _PATH_CACHE[key] = (now, result[0], result[1])
+    return result
+
+
+ensure_initialized()

--- a/Py4GWCoreLib/CombatEventQueue_src/helpers.py
+++ b/Py4GWCoreLib/CombatEventQueue_src/helpers.py
@@ -372,23 +372,37 @@ def _process_event(event):
     fval = event.float_value
     _events.append((ts, etype, agent, val, target, fval))
 
-    if etype in (EventType.SKILL_ACTIVATED, EventType.ATTACK_SKILL_ACTIVATED):
+    if etype == EventType.SKILL_ACTIVATE_PACKET:
+        # Earliest Reforged skill packet. Consumers still validate live Agent
+        # state before spending an interrupt, so false starts remain harmless.
+        _observed.setdefault(agent, set())
+        if val > 0:
+            _observed[agent].add(val)
+        _fire("skill_activated_timed", agent, val, target, ts)
+        _fire("skill_activated", agent, val, target)
+    elif etype in (EventType.SKILL_ACTIVATED, EventType.ATTACK_SKILL_ACTIVATED):
         _observed.setdefault(agent, set())
         if val > 0:
             _observed[agent].add(val)
         _check_stance(ts, agent, val)
         _create_estimated_recharge(ts, agent, val)
+        _fire("skill_activated_timed", agent, val, target, ts)
         _fire("skill_activated", agent, val, target)
     elif etype == EventType.INSTANT_SKILL_ACTIVATED:
         _observed.setdefault(agent, set())
         if val > 0:
             _observed[agent].add(val)
         _create_estimated_recharge(ts, agent, val)
+        _fire("skill_activated_timed", agent, val, target, ts)
         _fire("skill_activated", agent, val, target)
+    elif etype == EventType.CASTTIME:
+        _fire("cast_time", agent, int(_get_pending_skill(agent)), fval)
     elif etype in (EventType.SKILL_FINISHED, EventType.ATTACK_SKILL_FINISHED):
-        _fire("skill_finished", agent, _get_pending_skill(agent))
+        _fire("skill_finished", agent, int(val or _get_pending_skill(agent)))
+    elif etype in (EventType.SKILL_STOPPED, EventType.ATTACK_SKILL_STOPPED):
+        _fire("skill_stopped", agent, int(val or _get_pending_skill(agent)))
     elif etype == EventType.INTERRUPTED:
-        _fire("skill_interrupted", agent, _get_pending_skill(agent))
+        _fire("skill_interrupted", agent, int(val or _get_pending_skill(agent)))
     elif etype == EventType.ATTACK_STARTED:
         _fire("attack_started", agent, target)
     elif etype == EventType.DISABLED:
@@ -402,9 +416,14 @@ def _process_event(event):
     elif etype == EventType.KNOCKED_DOWN:
         _fire("knockdown", agent, fval)
     elif etype in (EventType.DAMAGE, EventType.CRITICAL, EventType.ARMOR_IGNORING):
-        _fire("damage", agent, target, fval, _get_pending_skill(target))
+        # Native damage packets expose the skill directly in ``value``.
+        # agent=damage target, target=damage source.  Falling back to the
+        # source's pending cast keeps older bindings usable.
+        skill_id = int(val or _get_pending_skill(target))
+        _fire("damage", agent, target, fval, skill_id)
     elif etype == EventType.HEALING:
-        _fire("healing", agent, target, fval, _get_pending_skill(target))
+        skill_id = int(val or _get_pending_skill(target))
+        _fire("healing", agent, target, fval, skill_id)
     elif etype == EventType.EFFECT_RENEWED:
         _fire("effect_renewed", agent, val)
     elif etype == EventType.SKILL_RECHARGE:

--- a/Py4GWCoreLib/CombatEvents.py
+++ b/Py4GWCoreLib/CombatEvents.py
@@ -1,18 +1,26 @@
 """
 CombatEventQueue - raw combat event access plus higher-level combat state APIs.
 
-The low-level queue facade stays close to the C++ `PyCombatEvents` binding.
-Higher-level combat-state helpers remain segmented under
-`CombatEventQueue_src.helpers`, while this module serves as the single public
-surface for both layers.
+Reforged Native exposes combat packets through ``PyAgentEvents``.  Older
+builds used ``PyCombatEvents``.  This module presents one stable queue facade
+for both backends and feeds the existing higher-level callback/state layer.
 """
 
 from __future__ import annotations
 
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Tuple
 
 import PySystem
-import PyAgentEvents
+
+try:
+    import PyAgentEvents  # Reforged Native backend
+except ModuleNotFoundError:
+    PyAgentEvents = None  # type: ignore[assignment]
+
+try:
+    import PyCombatEvents  # Legacy backend, retained only for compatibility
+except ModuleNotFoundError:
+    PyCombatEvents = None  # type: ignore[assignment]
 
 from .CombatEventQueue_src import helpers
 from .enums import EventType
@@ -20,26 +28,190 @@ from .enums import EventType
 
 _queue = None
 _initialized = False
+_backend_name = "unavailable"
+_native_event_type_map: dict[int, int] | None = None
+
+
+class _NormalizedAgentEvent:
+    """Small proxy normalizing Reforged event type values to EventType."""
+
+    __slots__ = (
+        "timestamp",
+        "event_type",
+        "agent_id",
+        "value",
+        "target_id",
+        "float_value",
+    )
+
+    def __init__(self, event) -> None:
+        self.timestamp = int(getattr(event, "timestamp", 0) or 0)
+        self.event_type = _normalize_event_type(getattr(event, "event_type", 0))
+        self.agent_id = int(getattr(event, "agent_id", 0) or 0)
+        self.value = int(getattr(event, "value", 0) or 0)
+        self.target_id = int(getattr(event, "target_id", 0) or 0)
+        self.float_value = float(getattr(event, "float_value", 0.0) or 0.0)
+
+    def as_tuple(self) -> Tuple[int, int, int, int, int, float]:
+        return (
+            self.timestamp,
+            self.event_type,
+            self.agent_id,
+            self.value,
+            self.target_id,
+            self.float_value,
+        )
+
+
+def _build_native_event_type_map() -> dict[int, int]:
+    """Map PyAgentEvents.PyEventType constants to the public EventType enum.
+
+    Current Reforged builds use the same integer values, but resolving by name
+    keeps the adapter correct if the native enum layout changes later.
+    """
+    mapping: dict[int, int] = {}
+    native_type = getattr(PyAgentEvents, "PyEventType", None) if PyAgentEvents else None
+    if native_type is None:
+        return mapping
+    for member in EventType:
+        try:
+            native_value = getattr(native_type, member.name)
+            mapping[int(native_value)] = int(member)
+        except Exception:
+            continue
+    return mapping
+
+
+def _normalize_event_type(value) -> int:
+    global _native_event_type_map
+    try:
+        raw = int(value)
+    except Exception:
+        return 0
+    if _native_event_type_map is None:
+        _native_event_type_map = _build_native_event_type_map()
+    return int(_native_event_type_map.get(raw, raw))
+
+
+class _AgentEventsQueueAdapter:
+    """Legacy queue-shaped wrapper around Reforged's module-level API."""
+
+    def Initialize(self) -> None:
+        if PyAgentEvents is None:
+            return
+        try:
+            if not bool(PyAgentEvents.is_enabled()):
+                PyAgentEvents.enable()
+        except Exception:
+            # Some native builds do not expose a reliable pre-enable state.
+            PyAgentEvents.enable()
+
+    def Terminate(self) -> None:
+        if PyAgentEvents is None:
+            return
+        try:
+            if bool(PyAgentEvents.is_enabled()):
+                PyAgentEvents.disable()
+        except Exception:
+            try:
+                PyAgentEvents.disable()
+            except Exception:
+                pass
+
+    def IsInitialized(self) -> bool:
+        if PyAgentEvents is None:
+            return False
+        try:
+            return bool(PyAgentEvents.is_enabled())
+        except Exception:
+            return False
+
+    def GetAndClearEvents(self):
+        if PyAgentEvents is None:
+            return []
+        try:
+            return [_NormalizedAgentEvent(e) for e in (PyAgentEvents.get_and_clear_events() or [])]
+        except Exception:
+            return []
+
+    def PeekEvents(self):
+        if PyAgentEvents is None:
+            return []
+        try:
+            return [_NormalizedAgentEvent(e) for e in (PyAgentEvents.peek_events() or [])]
+        except Exception:
+            return []
+
+    def SetMaxEvents(self, count: int) -> None:
+        # Reforged exposes a fixed native capacity, not a writable max size.
+        return None
+
+    def GetMaxEvents(self) -> int:
+        if PyAgentEvents is None:
+            return 0
+        try:
+            return int(PyAgentEvents.get_capacity() or 0)
+        except Exception:
+            return 0
+
+    def GetQueueSize(self) -> int:
+        if PyAgentEvents is None:
+            return 0
+        try:
+            return int(PyAgentEvents.get_event_count() or 0)
+        except Exception:
+            return 0
 
 
 def _ensure_init():
-    """Initialize the native combat event queue on first use."""
-    global _queue, _initialized
-    if _initialized:
+    """Initialize the available native combat-event backend on first use."""
+    global _queue, _initialized, _backend_name
+    if _initialized and _queue is not None:
         return
-    _queue = PyCombatEvents.GetCombatEventQueue()
-    if not _queue.IsInitialized():
-        _queue.Initialize()
-    _initialized = True
+
+    try:
+        if PyAgentEvents is not None:
+            candidate = _AgentEventsQueueAdapter()
+            candidate.Initialize()
+            if candidate.IsInitialized():
+                _queue = candidate
+                _backend_name = "PyAgentEvents"
+                _initialized = True
+                return
+
+        if PyCombatEvents is not None:
+            candidate = PyCombatEvents.GetCombatEventQueue()
+            if not candidate.IsInitialized():
+                candidate.Initialize()
+            if candidate.IsInitialized():
+                _queue = candidate
+                _backend_name = "PyCombatEvents"
+                _initialized = True
+                return
+
+        _queue = None
+        _backend_name = "unavailable"
+        _initialized = False
+    except Exception as exc:
+        # Keep retrying on later calls; native hooks can become available after
+        # the first module-import frame.
+        _queue = None
+        _initialized = False
+        _backend_name = f"unavailable: {exc!r}"
+
 
 #region CombatEventQueue
 class CombatEventQueue:
-    """
-    Raw combat event queue facade.
+    """Raw combat-event queue facade shared by Reforged and legacy builds."""
 
-    Use this class when you want direct access to the native combat-event
-    stream without any interpreted combat-state logic.
-    """
+    @staticmethod
+    def IsAvailable() -> bool:
+        return PyAgentEvents is not None or PyCombatEvents is not None
+
+    @staticmethod
+    def GetBackendName() -> str:
+        _ensure_init()
+        return str(_backend_name)
 
     @staticmethod
     def GetQueue():
@@ -96,27 +268,21 @@ class CombatEventQueue:
         _ensure_init()
         if not _queue:
             return 0
-        return _queue.GetMaxEvents()
+        return int(_queue.GetMaxEvents() or 0)
 
     @staticmethod
     def GetQueueSize() -> int:
         _ensure_init()
         if not _queue:
             return 0
-        return _queue.GetQueueSize()
-    
+        return int(_queue.GetQueueSize() or 0)
+
+
 #region CombatEvents
 class CombatEvents:
-    """
-    Public combat-events manager API.
-
-    Raw event ingestion, state mining, and callback dispatch helpers live in
-    `CombatEventQueue_src.helpers`. This class intentionally exposes only the
-    external API used by the rest of the codebase.
-    """
+    """Public combat-event manager and callback API."""
 
     _callback_name = "CombatEvents.Update"
-
 
     @staticmethod
     def GetEvents() -> List[Tuple[int, int, int, int, int, float]]:
@@ -153,6 +319,7 @@ class CombatEvents:
         if not helpers._is_callback_active():
             return []
         skill_types = {
+            helpers.EventType.SKILL_ACTIVATE_PACKET,
             helpers.EventType.SKILL_ACTIVATED,
             helpers.EventType.ATTACK_SKILL_ACTIVATED,
             helpers.EventType.SKILL_FINISHED,
@@ -173,12 +340,25 @@ class CombatEvents:
         helpers._callbacks.setdefault("skill_activated", []).append(cb)
 
     @staticmethod
+    def OnSkillActivatedTimed(cb: Callable[[int, int, int, int], None]):
+        """Register a cast-start callback that also receives native timestamp."""
+        helpers._callbacks.setdefault("skill_activated_timed", []).append(cb)
+
+    @staticmethod
     def OnSkillFinished(cb: Callable[[int, int], None]):
         helpers._callbacks.setdefault("skill_finished", []).append(cb)
 
     @staticmethod
+    def OnSkillStopped(cb: Callable[[int, int], None]):
+        helpers._callbacks.setdefault("skill_stopped", []).append(cb)
+
+    @staticmethod
     def OnSkillInterrupted(cb: Callable[[int, int], None]):
         helpers._callbacks.setdefault("skill_interrupted", []).append(cb)
+
+    @staticmethod
+    def OnCastTime(cb: Callable[[int, int, float], None]):
+        helpers._callbacks.setdefault("cast_time", []).append(cb)
 
     @staticmethod
     def OnAttackStarted(cb: Callable[[int, int], None]):
@@ -225,34 +405,68 @@ class CombatEvents:
         helpers._process_pending_events(CombatEventQueue)
 
     @staticmethod
-    def Enable():
-        #deactivated by design
-        helpers._set_callback_active(False)
-        import PyCallback
-        PyCallback.PyCallback.Register(
-             CombatEvents._callback_name,
-             PyCallback.Phase.Data,
-             CombatEvents.Update,
-             priority=7,
-             context=PyCallback.Context.Draw
-         )
+    def Enable() -> bool:
+        if not CombatEventQueue.IsAvailable():
+            helpers._set_callback_active(False)
+            return False
+
+        CombatEventQueue.Initialize()
+        if not CombatEventQueue.IsInitialized():
+            helpers._set_callback_active(False)
+            return False
+
+        try:
+            import PyCallback
+            try:
+                PyCallback.PyCallback.RemoveByName(CombatEvents._callback_name)
+            except Exception:
+                pass
+            helpers._set_callback_active(True)
+            PyCallback.PyCallback.Register(
+                CombatEvents._callback_name,
+                PyCallback.Phase.Data,
+                CombatEvents.Update,
+                priority=7,
+                context=PyCallback.Context.Draw,
+            )
+            return True
+        except Exception:
+            helpers._set_callback_active(False)
+            return False
 
     @staticmethod
     def Disable():
         helpers._set_callback_active(False)
         try:
             import PyCallback
-
             PyCallback.PyCallback.RemoveByName(CombatEvents._callback_name)
         except Exception:
             pass
+        CombatEventQueue.Terminate()
+
 
 COMBAT_EVENTS = CombatEvents()
 
 try:
-    CombatEvents.Enable()
-except Exception as e:
-    PySystem.Console.Log("CombatEvents", f"Module init error: {e}", PySystem.Console.MessageType.Error)
+    enabled = CombatEvents.Enable()
+    if enabled:
+        PySystem.Console.Log(
+            "CombatEvents",
+            f"Native combat events active via {CombatEventQueue.GetBackendName()}",
+            PySystem.Console.MessageType.Info,
+        )
+    else:
+        PySystem.Console.Log(
+            "CombatEvents",
+            "Native event backend unavailable; polling fallback remains active",
+            PySystem.Console.MessageType.Warning,
+        )
+except Exception as exc:
+    PySystem.Console.Log(
+        "CombatEvents",
+        f"Event initialization failed; polling fallback remains active: {exc}",
+        PySystem.Console.MessageType.Warning,
+    )
 
 
 EventTypes = EventType


### PR DESCRIPTION
Summary

This PR improves the combat-event bridge and interrupt timing without adding any build-specific targeting or team logic.

Changes

* Adds compatibility support for native combat-event handling.
* Normalizes skill activation, cast-time, finish, stop, and interrupt events.
* Adds timed skill-activation tracking.
* Uses native cast timing where available for more accurate interrupt feasibility checks.
* Adds ReforgedSupport as a small shared observer for cast start and duration data.
* Keeps the existing polling and skill-data logic as fallback.

Why

Static skill activation times are not always accurate after Fast Casting and other cast-time modifiers. Native cast-time events provide a more reliable interrupt window and reduce late or unnecessary interrupt attempts.

Safety

* No damage telemetry is enabled.
* No Keystone / HR KeySoJway-specific logic is included.
* Existing behavior remains available as fallback if native events are unavailable.

Testing

* All included Python files pass py_compile.
* Tested with native cast start, finish, stop, and interrupt events.