### PR TITLE
Fix Dark Aura self-lockout and redundant adjacency scan in the N/A build

### DIFF
--- a/Py4GWCoreLib/Builds/Necromancer/N_A/Soul Taker Daggers Dark Aura.py
+++ b/Py4GWCoreLib/Builds/Necromancer/N_A/Soul Taker Daggers Dark Aura.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from Py4GWCoreLib import AgentArray, BuildMgr, Profession, Range, Routines
+from Py4GWCoreLib import BuildMgr, Profession, Range, Routines
 from Py4GWCoreLib.Agent import Agent
 from Py4GWCoreLib.Builds.Any.HeroAI import HeroAI_Build
 from Py4GWCoreLib.Builds.Skills import SkillsTemplate
@@ -63,22 +63,13 @@ class Soul_Taker_Daggers_Dark_Aura(BuildMgr):
         # adjacent to the target, so a clustered pick pays out twice.
         self.dagger_target_type = "EnemyClustered"
 
-    def _get_player_contact_count(self) -> int:
-        player_x, player_y = Player.GetXY()
-        enemy_array = Routines.Agents.GetFilteredEnemyArray(player_x, player_y, Range.Adjacent.value)
-        enemy_array = AgentArray.Filter.ByCondition(
-            enemy_array,
-            lambda agent_id: Agent.IsValid(agent_id) and not Agent.IsDead(agent_id),
-        )
-        return len(enemy_array or [])
-
     def _is_in_melee_contact(self, target_agent_id: int) -> bool:
         if not target_agent_id or not Agent.IsValid(target_agent_id) or Agent.IsDead(target_agent_id):
             return False
         return Utils.Distance(Player.GetXY(), Agent.GetXY(target_agent_id)) <= Range.Adjacent.value
 
     def _auto_attack_cluster(self):
-        return (yield from self.AutoAttack(target_type="EnemyClustered"))
+        return (yield from self.AutoAttack(target_type=self.dagger_target_type))
 
     def _should_upkeep(self, skill_id: int, mid_chain: bool) -> bool:
         """Allow upkeep casts freely, but mid-combo only when the buff is gone.
@@ -102,9 +93,12 @@ class Soul_Taker_Daggers_Dark_Aura(BuildMgr):
         # early: while it is off cooldown the helper records that we were
         # knocked down, which is what lets it fire again just after a
         # knockdown rather than only during one.
+        # contact_count is left to the helper: it runs the same adjacency scan
+        # itself, but only once its cheap gates have passed. Computing it here
+        # would pay for a full enemy-array scan on every tick of the skill's
+        # uptime and on every tick we are only close to aggro.
         if self.IsSkillEquipped(I_AM_UNSTOPPABLE_ID) and (
             yield from self.skillbook.Any.NoAttribute.I_Am_Unstoppable(
-                contact_count=self._get_player_contact_count(),
                 min_adjacent_enemies=2,
                 refresh_window_ms=1000,
                 aftercast_delay=150,

--- a/Py4GWCoreLib/Builds/Skills/necromancer/DeathMagic.py
+++ b/Py4GWCoreLib/Builds/Skills/necromancer/DeathMagic.py
@@ -213,7 +213,12 @@ class DeathMagic:
 
         now_ms = int(Utils.GetBaseTimestamp())
         assumed_targets = getattr(self.build, "_dark_aura_assumed_targets", {})
-        if int(assumed_targets.get(target_agent_id, 0) or 0) > now_ms:
+        # The assumed-active window exists because another ally's enchantments
+        # cannot be read reliably. Our own can, and were already checked above,
+        # so applying the window to ourselves would refuse to reapply the aura
+        # for the rest of it every time an enemy strips it early - which on a
+        # self-sacrifice bar is most of the damage gone for up to 25 seconds.
+        if target_agent_id != Player.GetAgentID() and int(assumed_targets.get(target_agent_id, 0) or 0) > now_ms:
             return False
 
         cast_result = yield from self.build.CastSkillIDAndRestoreTarget(


### PR DESCRIPTION
Two fixes to the N/A Soul Taker Daggers (Dark Aura) build, both found by reading
the cast path rather than by playing it.

## Dark Aura could not be reapplied for up to 25 seconds after being stripped

`DeathMagic.Dark_Aura` recorded its 25s `_dark_aura_assumed_targets` window for
the caster as well as for allies. That window exists because another ally's
enchantments cannot be read reliably — but our own can, and are already checked
immediately above it.

On the `self_only` bar the effect was that an aura stripped early could not be
reapplied for the remainder of the window, and there is no party fallback to
cover it. Soul Taker makes every swing a sacrifice and Dark Aura is what turns
those sacrifices into damage, so this is most of the build's damage gone for up
to 25 seconds while it keeps swinging daggers.

The guard now skips the assumed-active window when the target is the local
player.

## Redundant per-tick adjacency scan

The build passed `contact_count=self._get_player_contact_count()` to
`I_Am_Unstoppable`. The helper performs the same adjacency scan itself, but only
after its `IsSkillEquipped` / `IsInAggro` / refresh-window early returns —
so supplying the value eagerly defeated all three and paid for a full
enemy-array scan on every tick of the skill's uptime, and on every tick the
build was merely close to aggro.

Dropping the argument also removes the duplicated `_get_player_contact_count`
helper and a now-unused `AgentArray` import.

Separately, `_auto_attack_cluster` now reads `self.dagger_target_type` instead
of repeating `"EnemyClustered"` as a second hardcoded literal that could drift
from it.

## Verification

`python -m py_compile` passes on both files. **Not verified in an injected
client** — the repo cannot be imported outside the game, so this is source
reasoning plus a compile check, not runtime proof. The Dark Aura change is the
one worth watching in play: the aura should now come back promptly after an
enchantment strip.
