### PR TITLE
Add PvX Heroic Refrain Spear support on top of the Paragon refrain rotation

### DIFF
--- a/HeroAI/custom_skill_src/paragon.py
+++ b/HeroAI/custom_skill_src/paragon.py
@@ -623,6 +623,14 @@ class ParagonSkills:
         skill_data[skill.SkillID] = skill
 
         skill = CustomSkill()
+        skill.SkillID = GLOBAL_CACHE.Skill.GetID("Vicious_Attack")
+        skill.SkillType = SkillType.Attack.value
+        skill.TargetAllegiance = Skilltarget.Enemy.value
+        skill.Nature = SkillNature.Offensive.value
+        skill.Conditions.RequireWeapon = "Spear"
+        skill_data[skill.SkillID] = skill
+
+        skill = CustomSkill()
         skill.SkillID = GLOBAL_CACHE.Skill.GetID("Wearying_Spear")
         skill.SkillType = SkillType.Attack.value
         skill.TargetAllegiance = Skilltarget.Enemy.value

--- a/HeroAI/targeting.py
+++ b/HeroAI/targeting.py
@@ -95,8 +95,7 @@ def TargetAllyByPredicate(
 
     return Utils.GetFirstFromArray(ally_array)
 
-def TargetLowestAlly(other_ally=False,filter_skill_id=0):
-    distance = Range.Spellcast.value
+def TargetLowestAlly(other_ally=False, filter_skill_id=0, distance=Range.Spellcast.value):
     ally_array = AgentArray.GetAllyArray()
     ally_array = FilterAllyArray(ally_array, distance, other_ally, filter_skill_id) 
      
@@ -160,16 +159,14 @@ def TargetAllyNonWeaponSpelled(distance=Range.Earshot.value):
     return Utils.GetFirstFromArray(ally_array)
 
 
-def TargetLowestAllyEnergy(other_ally=False, filter_skill_id=0, less_energy=1.0):
+def TargetLowestAllyEnergy(other_ally=False, filter_skill_id=0, less_energy=1.0, distance=Range.Spellcast.value):
     global BLOOD_IS_POWER, BLOOD_RITUAL
     from Py4GWCoreLib.GlobalCache.WhiteboardLocks import (
         BLOOD_ENERGY_BUFF_LOCK_KEY,
         filter_unlocked_buff_targets,
     )
     from .utils import (CheckForEffect, GetEnergyValues, IsValidEnergyValue)
-    
-    
-    distance = Range.Spellcast.value
+
     ally_array = AgentArray.GetAllyArray()
     ally_array = FilterAllyArray(ally_array, distance, other_ally, filter_skill_id)
     ally_array = AgentArray.Filter.ByCondition(ally_array, lambda agent_id: not CheckForEffect(agent_id, BLOOD_IS_POWER))
@@ -197,9 +194,8 @@ def TargetLowestAllyEnergy(other_ally=False, filter_skill_id=0, less_energy=1.0)
     return ally
 
 
-def TargetLowestAllyCaster(other_ally=False, filter_skill_id=0):
+def TargetLowestAllyCaster(other_ally=False, filter_skill_id=0, distance=Range.Spellcast.value):
     from Py4GWCoreLib import Routines
-    distance = Range.Spellcast.value
     ally_array = AgentArray.GetAllyArray()
     ally_array = FilterAllyArray(ally_array, distance, other_ally, filter_skill_id)
     ally_array = AgentArray.Filter.ByCondition(ally_array, lambda agent_id: Routines.Checks.Agents.IsCaster(agent_id))
@@ -208,10 +204,9 @@ def TargetLowestAllyCaster(other_ally=False, filter_skill_id=0):
     return Utils.GetFirstFromArray(ally_array)
 
 
-def TargetLowestAllyMartial(other_ally=False, filter_skill_id=0):
+def TargetLowestAllyMartial(other_ally=False, filter_skill_id=0, distance=Range.Spellcast.value):
     from Py4GWCoreLib import Routines
     from .utils import HasIllusionaryWeaponry
-    distance = Range.Spellcast.value
     ally_array = AgentArray.GetAllyArray()
     ally_array = FilterAllyArray(ally_array, distance, other_ally, filter_skill_id)
     ally_array = AgentArray.Filter.ByCondition(ally_array, lambda agent_id: Routines.Checks.Agents.IsMartial(agent_id))
@@ -226,10 +221,9 @@ def TargetLowestAllyMartial(other_ally=False, filter_skill_id=0):
     return Utils.GetFirstFromArray(ally_array)
 
 
-def TargetLowestAllyMelee(other_ally=False, filter_skill_id=0):
+def TargetLowestAllyMelee(other_ally=False, filter_skill_id=0, distance=Range.Spellcast.value):
     from Py4GWCoreLib import Routines
     from .utils import HasIllusionaryWeaponry
-    distance = Range.Spellcast.value
     ally_array = AgentArray.GetAllyArray()
     ally_array = FilterAllyArray(ally_array, distance, other_ally, filter_skill_id)
     ally_array = AgentArray.Filter.ByCondition(ally_array, lambda agent_id: Routines.Checks.Agents.IsMelee(agent_id))
@@ -244,9 +238,8 @@ def TargetLowestAllyMelee(other_ally=False, filter_skill_id=0):
     return Utils.GetFirstFromArray(ally_array)
 
 
-def TargetLowestAllyRanged(other_ally=False, filter_skill_id=0):
+def TargetLowestAllyRanged(other_ally=False, filter_skill_id=0, distance=Range.Spellcast.value):
     from Py4GWCoreLib import Routines
-    distance = Range.Spellcast.value
     ally_array = AgentArray.GetAllyArray()
     ally_array = FilterAllyArray(ally_array, distance, other_ally, filter_skill_id)
     ally_array = AgentArray.Filter.ByCondition(ally_array, lambda agent_id: Routines.Checks.Agents.IsRanged(agent_id))

--- a/Py4GWCoreLib/BuildMgr.py
+++ b/Py4GWCoreLib/BuildMgr.py
@@ -404,7 +404,13 @@ class BuildMgr:
         from Py4GWCoreLib import Routines
         return Routines.Checks.Agents.IsCloseToAggro()
 
-    def ResolveAllyTarget(self, skill_id: int, custom_skill: CustomSkill | None = None) -> int:
+    def ResolveAllyTarget(
+        self,
+        skill_id: int,
+        custom_skill: CustomSkill | None = None,
+        *,
+        max_range: float | None = None,
+    ) -> int:
         from HeroAI.targeting import (
             TargetAllyByPredicate,
             TargetLowestAlly,
@@ -429,15 +435,26 @@ class BuildMgr:
 
         target_allegiance = custom_skill.TargetAllegiance
         targeting_strict = bool(custom_skill.Conditions.TargetingStrict)
+        # Ally selection defaults to spellcast range. max_range narrows the
+        # candidate pool itself rather than vetting the winner afterwards -
+        # vetting would let a single unreachable ally, who ranks first because
+        # ally sorting is by lowest health, block every other candidate.
+        from Py4GWCoreLib.enums_src.GameData_enums import Range
+
+        ally_distance = Range.Spellcast.value if max_range is None else max_range
+        # These four selectors do not share one default radius - notably
+        # TargetAllyNonWeaponSpelled already defaults to earshot - so only
+        # override when a caller actually asked for a narrower one.
+        range_kwargs = {} if max_range is None else {"distance": max_range}
 
         if target_allegiance == Skilltarget.MinionOrAllyNonEnchanted.value:
-            return TargetMinionOrAllyNonEnchanted(filter_skill_id=skill_id)
+            return TargetMinionOrAllyNonEnchanted(filter_skill_id=skill_id, **range_kwargs)
         if target_allegiance == Skilltarget.MinionNonEnchanted.value:
-            return TargetMinionNonEnchanted()
+            return TargetMinionNonEnchanted(**range_kwargs)
         if target_allegiance == Skilltarget.AllyNonEnchanted.value:
-            return TargetAllyNonEnchanted()
+            return TargetAllyNonEnchanted(**range_kwargs)
         if target_allegiance == Skilltarget.NonWeaponSpelledAlly.value:
-            return Player.GetAgentID() if TargetAllyNonWeaponSpelled() else 0
+            return Player.GetAgentID() if TargetAllyNonWeaponSpelled(**range_kwargs) else 0
 
         if target_allegiance in (
             Skilltarget.Ally.value,
@@ -462,23 +479,23 @@ class BuildMgr:
                 else:
                     weapon_spell_predicate = lambda agent_id: not Routines.Checks.Agents.IsWeaponSpelled(agent_id)
             if target_allegiance == Skilltarget.Ally.value:
-                base_target = TargetLowestAlly(other_ally=other_ally, filter_skill_id=skill_id)
+                base_target = TargetLowestAlly(other_ally=other_ally, filter_skill_id=skill_id, distance=ally_distance)
             elif target_allegiance == Skilltarget.AllyCaster.value:
-                base_target = TargetLowestAllyCaster(other_ally=other_ally, filter_skill_id=skill_id)
+                base_target = TargetLowestAllyCaster(other_ally=other_ally, filter_skill_id=skill_id, distance=ally_distance)
                 base_predicate = lambda agent_id: Routines.Checks.Agents.IsCaster(agent_id)
             elif target_allegiance == Skilltarget.AllyMartial.value:
-                base_target = TargetLowestAllyMartial(other_ally=other_ally, filter_skill_id=skill_id)
+                base_target = TargetLowestAllyMartial(other_ally=other_ally, filter_skill_id=skill_id, distance=ally_distance)
                 base_predicate = lambda agent_id: Routines.Checks.Agents.IsMartial(agent_id)
                 include_spirit_pets = True
             elif target_allegiance == Skilltarget.AllyMartialMelee.value:
-                base_target = TargetLowestAllyMelee(other_ally=other_ally, filter_skill_id=skill_id)
+                base_target = TargetLowestAllyMelee(other_ally=other_ally, filter_skill_id=skill_id, distance=ally_distance)
                 base_predicate = lambda agent_id: Routines.Checks.Agents.IsMelee(agent_id)
                 include_spirit_pets = True
             elif target_allegiance == Skilltarget.AllyMartialRanged.value:
-                base_target = TargetLowestAllyRanged(other_ally=other_ally, filter_skill_id=skill_id)
+                base_target = TargetLowestAllyRanged(other_ally=other_ally, filter_skill_id=skill_id, distance=ally_distance)
                 base_predicate = lambda agent_id: Routines.Checks.Agents.IsRanged(agent_id)
             elif target_allegiance == Skilltarget.OtherAlly.value:
-                base_target = TargetLowestAlly(other_ally=True, filter_skill_id=skill_id)
+                base_target = TargetLowestAlly(other_ally=True, filter_skill_id=skill_id, distance=ally_distance)
 
             if weapon_spell_predicate is not None:
                 if base_predicate is None:
@@ -492,6 +509,7 @@ class BuildMgr:
                     other_ally=other_ally,
                     filter_skill_id=skill_id,
                     less_energy=custom_skill.Conditions.LessEnergy,
+                    distance=ally_distance,
                 )
 
             predicate = self._build_custom_skill_target_predicate(
@@ -506,18 +524,19 @@ class BuildMgr:
                 other_ally=other_ally,
                 filter_skill_id=skill_id,
                 include_spirit_pets=include_spirit_pets,
+                distance=ally_distance,
             )
             if filtered_target:
                 return filtered_target
 
             if not targeting_strict and target_allegiance != Skilltarget.OtherAlly.value:
-                return TargetLowestAlly(other_ally=other_ally, filter_skill_id=skill_id)
+                return TargetLowestAlly(other_ally=other_ally, filter_skill_id=skill_id, distance=ally_distance)
             return 0
+        # Resurrection deliberately keeps full spellcast reach: a corpse cannot
+        # walk into earshot, so narrowing it would just refuse the raise.
         if target_allegiance == Skilltarget.DeadAlly.value:
-            from Py4GWCoreLib.enums_src.GameData_enums import Range
             return Routines.Agents.GetDeadAlly(Range.Spellcast.value)
         if target_allegiance == Skilltarget.ResurrectionAlly.value:
-            from Py4GWCoreLib.enums_src.GameData_enums import Range
             return Routines.Agents.GetResurrectionTarget(
                 Range.Spellcast.value,
                 reserve=True,
@@ -527,6 +546,76 @@ class BuildMgr:
             return Player.GetAgentID()
 
         return 0
+
+    def ResolveAllyTargetInRange(
+        self,
+        skill_id: int,
+        custom_skill: CustomSkill | None = None,
+        *,
+        max_range: float | None = None,
+    ) -> int:
+        """ResolveAllyTarget restricted to allies within max_range (default earshot).
+
+        Ally targeting resolves out to spellcast range. Echoes and refrains are
+        renewed by chants and shouts, which only reach earshot, so an ally
+        buffed from beyond earshot can never have that buff renewed - it simply
+        expires and gets paid for again on the next recharge.
+
+        The restriction applies to the ally-selection allegiances. Resurrection
+        targeting keeps its own reach, for the obvious reason that a corpse
+        cannot close the distance.
+
+        The radius narrows the candidate pool rather than vetting the winner.
+        Vetting afterwards would deadlock: ally selection ranks by lowest health
+        and a straggler out of earshot is usually also the hurt one, so it would
+        be picked first, rejected, and picked again on every tick - blocking the
+        allies standing next to us for as long as it stayed there.
+        """
+        from Py4GWCoreLib import Range
+
+        return self.ResolveAllyTarget(
+            skill_id,
+            custom_skill,
+            max_range=Range.Earshot.value if max_range is None else max_range,
+        )
+
+    def SpreadEchoToAlly(
+        self,
+        skill_id: int,
+        *,
+        max_range: float | None = None,
+        aftercast_delay: int = 250,
+    ):
+        """Put an ally-targeted echo on someone in range who does not carry it.
+
+        Every refrain and finale shares this shape: find an ally still missing
+        the echo (the skill's own id is used as the filter, so anyone who
+        already has it drops out), refuse anyone outside renewal range, cast,
+        and put our own target back. Repeated calls therefore converge on full
+        party coverage and then go quiet.
+        """
+        # Castability first: resolving an ally walks the party several times
+        # over, and callers retry every refrain on the bar every tick, so doing
+        # that work before checking recharge/energy would throw it away on the
+        # overwhelming majority of ticks. CanCastSkillID subsumes the equipped
+        # check and is the same gate the cast below applies anyway.
+        if not self.CanCastSkillID(skill_id):
+            return False
+
+        target_agent_id = self.ResolveAllyTargetInRange(
+            skill_id,
+            self.GetCustomSkill(skill_id),
+            max_range=max_range,
+        )
+        if not target_agent_id:
+            return False
+
+        return (yield from self.CastSkillIDAndRestoreTarget(
+            skill_id=skill_id,
+            target_agent_id=target_agent_id,
+            log=False,
+            aftercast_delay=aftercast_delay,
+        ))
 
     def ResolvePreferredAllyTarget(
         self,

--- a/Py4GWCoreLib/Builds/Paragon/P_W/Defensive Refrain.py
+++ b/Py4GWCoreLib/Builds/Paragon/P_W/Defensive Refrain.py
@@ -2,16 +2,15 @@ from Py4GWCoreLib import Profession
 from Py4GWCoreLib import Routines
 from Py4GWCoreLib.Builds.Any.HeroAI import HeroAI_Build
 from Py4GWCoreLib import BuildMgr
+from Py4GWCoreLib.Player import Player
 from Py4GWCoreLib.Skill import Skill
 from Py4GWCoreLib.Builds.Skills import SkillsTemplate
 
 Heroic_Refrain_ID = Skill.GetID("Heroic_Refrain")
 Anthem_of_Flame_ID = Skill.GetID("Anthem_of_Flame")
 Theyre_on_Fire_ID = Skill.GetID("Theyre_on_Fire")
-Mending_Refrain_ID = Skill.GetID("Mending_Refrain")
 Hasty_Refrain_ID = Skill.GetID("Hasty_Refrain")
 Aggressive_Refrain_ID = Skill.GetID("Aggressive_Refrain")
-Mighty_Throw_ID = Skill.GetID("Mighty_Throw")
 Stand_Your_Ground_ID = Skill.GetID("Stand_Your_Ground")
 For_Great_Justice_ID = Skill.GetID("For_Great_Justice")
 Theres_Nothing_to_Fear_ID = Skill.GetID("Theres_Nothing_to_Fear")
@@ -21,42 +20,103 @@ Never_Surrender_ID = Skill.GetID("Never_Surrender")
 Blazing_Finale_ID = Skill.GetID("Blazing_Finale")
 Ebon_Vanguard_Assassin_Support_ID = Skill.GetID("Ebon_Vanguard_Assassin_Support")
 Ebon_Battle_Standard_of_Wisdom_ID = Skill.GetID("Ebon_Battle_Standard_of_Wisdom")
+Ebon_Battle_Standard_of_Honor_ID = Skill.GetID("Ebon_Battle_Standard_of_Honor")
 Protectors_Defense_ID = Skill.GetID("Protectors_Defense")
 Cant_Touch_This_ID = Skill.GetID("Cant_Touch_This")
 Make_Your_Time_ID = Skill.GetID("Make_Your_Time")
 Angelic_Protection_ID = Skill.GetID("Angelic_Protection")
 
+# Added for the PvX "P/any Heroic Refrain Spear" variants.
+Mighty_Throw_ID = Skill.GetID("Mighty_Throw")
+Vicious_Attack_ID = Skill.GetID("Vicious_Attack")
+Spear_of_Redemption_ID = Skill.GetID("Spear_of_Redemption")
+Go_for_the_Eyes_ID = Skill.GetID("Go_for_the_Eyes")
+Find_Their_Weakness_ID = Skill.GetID("Find_Their_Weakness")
+Fall_Back_ID = Skill.GetID("Fall_Back")
+Bladeturn_Refrain_ID = Skill.GetID("Bladeturn_Refrain")
+Lyric_of_Zeal_ID = Skill.GetID("Lyric_of_Zeal")
+Mending_Refrain_ID = Skill.GetID("Mending_Refrain")
+Energizing_Finale_ID = Skill.GetID("Energizing_Finale")
+Burning_Refrain_ID = Skill.GetID("Burning_Refrain")
+To_the_Limit_ID = Skill.GetID("To_the_Limit")
+You_Move_Like_a_Dwarf_ID = Skill.GetID("You_Move_Like_a_Dwarf")
+Finish_Him_ID = Skill.GetID("Finish_Him")
+Great_Dwarf_Weapon_ID = Skill.GetID("Great_Dwarf_Weapon")
+Breath_of_the_Great_Dwarf_ID = Skill.GetID("Breath_of_the_Great_Dwarf")
+Blind_ID = Skill.GetID("Blind")
+
 
 class Paragon_Refrain(BuildMgr):
+    """P/W Heroic Refrain support Paragon.
+
+    Ports PvX "Build:P/any Heroic Refrain Spear" and its two P/W variants
+    (Mighty Throw and Motivation Support) on top of the original Defensive
+    Refrain bar. The engine is Heroic Refrain: it is stacked on ourselves first
+    so every copy we hand out is cast at the highest Leadership we can reach,
+    then spread across the party, and from then on "They're on Fire!" alone
+    renews it on everyone - a refrain is reapplied whenever a chant or shout
+    *ends* on its holder.
+
+    That mechanic is why almost every shout helper on this bar refuses to
+    recast while its own copy is still running: replacing a shout is inferred
+    not to end it, so an early recast would silently skip a party-wide refrain
+    renewal. That inference is unconfirmed in an injected client and is written
+    up on Command.Cant_Touch_This. It is
+    also why the spear attacks are clamped to spear range - which is the same
+    1012 units as earshot, so staying in range to attack is the same thing as
+    staying in range to renew.
+    """
+
     def __init__(self, match_only: bool = False):
         super().__init__(
             name="Defensive Refrain",
             required_primary=Profession.Paragon,
             required_secondary=Profession.Warrior,
             template_code="OQGkUNlnpiy0ZNQYPWNm72G4VhoH",
+            # The three skills every PvX variant of this build carries. Keeping
+            # the gate at three is what lets one class match the original bar,
+            # the Mighty Throw variant and the Motivation Support variant.
             required_skills=[
                 Heroic_Refrain_ID,
                 Theyre_on_Fire_ID,
                 Theres_Nothing_to_Fear_ID,
             ],
+            # Everything here is driven below. That is not optional: declaring a
+            # skill masks it out of the HeroAI fallback, so a declared skill the
+            # build never casts is a skill nobody casts.
             optional_skills=[
                 Save_Yourselves_luxon_ID,
                 Save_Yourselves_kurzick_ID,
                 Anthem_of_Flame_ID,
-                Mending_Refrain_ID,
                 Hasty_Refrain_ID,
                 Never_Surrender_ID,
                 Aggressive_Refrain_ID,
-                Mighty_Throw_ID,
                 Stand_Your_Ground_ID,
                 For_Great_Justice_ID,
                 Blazing_Finale_ID,
                 Ebon_Vanguard_Assassin_Support_ID,
                 Ebon_Battle_Standard_of_Wisdom_ID,
+                Ebon_Battle_Standard_of_Honor_ID,
                 Protectors_Defense_ID,
                 Cant_Touch_This_ID,
                 Make_Your_Time_ID,
                 Angelic_Protection_ID,
+                Mighty_Throw_ID,
+                Vicious_Attack_ID,
+                Spear_of_Redemption_ID,
+                Go_for_the_Eyes_ID,
+                Find_Their_Weakness_ID,
+                Fall_Back_ID,
+                Bladeturn_Refrain_ID,
+                Lyric_of_Zeal_ID,
+                Mending_Refrain_ID,
+                Energizing_Finale_ID,
+                Burning_Refrain_ID,
+                To_the_Limit_ID,
+                You_Move_Like_a_Dwarf_ID,
+                Finish_Him_ID,
+                Great_Dwarf_Weapon_ID,
+                Breath_of_the_Great_Dwarf_ID,
             ],
         )
         if match_only:
@@ -64,78 +124,243 @@ class Paragon_Refrain(BuildMgr):
 
         self.SetFallback("HeroAI", HeroAI_Build(standalone_fallback=True))
         self.SetSkillCastingFn(self._run_local_skill_logic)
-        self.skills: SkillsTemplate = SkillsTemplate(self)
+        # Named skillbook, not skills: BuildMgr.skills is the list[int] of
+        # equipped skill ids that ValidateSkills sorts, and shadowing it with
+        # the helper namespace makes that call raise TypeError.
+        self.skillbook: SkillsTemplate = SkillsTemplate(self)
+        # Spear attacks are ranged, so there is no reason to prefer whatever is
+        # closest - pick the target that dies soonest.
+        self.spear_target_type = "EnemyInjured"
 
-    def _run_local_skill_logic(self):
-        if not Routines.Checks.Skills.CanCast():
-            yield from Routines.Yield.wait(100)
+    def _run_upkeep(self):
+        """Refrain maintenance. Runs in and out of combat.
+
+        Everything here has to be reachable while travelling: the refrains are
+        maintained continuously, not re-established at every pull.
+        """
+        # First, and deliberately so. Aggressive Refrain is a single cast that
+        # the bar's shouts then renew forever, so the sooner it lands the sooner
+        # we stop thinking about it - after that its HasEffect guard returns
+        # False instantly and it costs nothing to keep asking. It used to sit
+        # below the in-aggro guard AND below Heroic Refrain, which is why it was
+        # effectively never cast: by the time we were in combat, Heroic Refrain
+        # was spreading across the party one ally per tick and never yielded the
+        # tick to it.
+        if self.IsSkillEquipped(Aggressive_Refrain_ID) and (yield from self.skillbook.Paragon.Leadership.Aggressive_Refrain()):
+            return True
+
+        # The elite, and the reason for the bar. Self-stacks first, then walks
+        # the party; the helper's own logic decides which.
+        if self.IsSkillEquipped(Heroic_Refrain_ID) and (yield from self.skillbook.Paragon.Leadership.Heroic_Refrain()):
+            return True
+
+        if self.IsSkillEquipped(Anthem_of_Flame_ID) and (yield from self.skillbook.Paragon.Leadership.Anthem_of_Flame()):
+            return True
+
+        # The renewal engine. PvX: this shout alone is enough to keep Heroic
+        # Refrain up on the whole party, and it is also what keeps Aggressive
+        # Refrain alive above.
+        if self.IsSkillEquipped(Theyre_on_Fire_ID) and (yield from self.skillbook.Paragon.Leadership.Theyre_on_Fire()):
+            return True
+
+        # The secondary echoes are worth a tick while travelling, but not ahead
+        # of the defensive shouts once the fight starts - in combat they are
+        # retried at the tail of the rotation instead.
+        if self.IsInAggro():
             return False
-        yield from self.AutoAttack()
 
-        if self.IsSkillEquipped(Heroic_Refrain_ID) and (yield from self.skills.Paragon.Leadership.Heroic_Refrain()):
+        if (yield from self._run_refrain_spreading()):
             return True
 
-        if self.IsSkillEquipped(Mending_Refrain_ID) and (yield from self.skills.Paragon.Motivation.Mending_Refrain()):
+        # Travel speed. Ends on the holder's next attack, so the helper keeps it
+        # to genuine out-of-combat movement.
+        if self.IsSkillEquipped(Fall_Back_ID) and (yield from self.skillbook.Paragon.Command.Fall_Back()):
             return True
 
-        if self.IsSkillEquipped(Hasty_Refrain_ID) and (yield from self.skills.Paragon.Motivation.Hasty_Refrain()):
+        return False
+
+    def _run_refrain_spreading(self):
+        """Spread the maintainable echoes over the party.
+
+        Each helper picks an ally in earshot who does not have the echo yet, so
+        together they converge on full coverage and then go quiet - which is why
+        they are cheap to retry every tick.
+        """
+        if self.IsSkillEquipped(Mending_Refrain_ID) and (yield from self.skillbook.Paragon.Motivation.Mending_Refrain()):
             return True
 
-        if self.IsSkillEquipped(Aggressive_Refrain_ID) and (yield from self.skills.Paragon.Leadership.Aggressive_Refrain()):
+        if self.IsSkillEquipped(Bladeturn_Refrain_ID) and (yield from self.skillbook.Paragon.Command.Bladeturn_Refrain()):
             return True
 
-        if self.IsSkillEquipped(Anthem_of_Flame_ID) and (yield from self.skills.Paragon.Leadership.Anthem_of_Flame()):
+        if self.IsSkillEquipped(Energizing_Finale_ID) and (yield from self.skillbook.Paragon.Motivation.Energizing_Finale()):
             return True
 
-        if self.IsSkillEquipped(Theyre_on_Fire_ID) and (yield from self.skills.Paragon.Leadership.Theyre_on_Fire()):
+        # Burning Refrain and Blazing Finale both pay off through "They're on
+        # Fire!", which is permanently up on this bar.
+        if self.IsSkillEquipped(Burning_Refrain_ID) and (yield from self.skillbook.Paragon.Motivation.Burning_Refrain()):
             return True
 
-        if not self.IsInAggro():
-            return False
-
-        if self.IsSkillEquipped(Angelic_Protection_ID) and (yield from self.skills.Paragon.Leadership.Angelic_Protection(health_threshold=0.30)):
+        if self.IsSkillEquipped(Blazing_Finale_ID) and (yield from self.skillbook.Paragon.Motivation.Blazing_Finale()):
             return True
 
-        if self.IsSkillEquipped(Save_Yourselves_luxon_ID) and (yield from self.skills.Any.NoAttribute.Save_Yourselves_luxon()):
+        if self.IsSkillEquipped(Hasty_Refrain_ID) and (yield from self.skillbook.Paragon.Motivation.Hasty_Refrain()):
             return True
 
-        if self.IsSkillEquipped(Save_Yourselves_kurzick_ID) and (yield from self.skills.Any.NoAttribute.Save_Yourselves_kurzick()):
+        return False
+
+    def _run_combat(self):
+        """Party defence, adrenaline, offensive support and spear damage."""
+        if self.IsSkillEquipped(Angelic_Protection_ID) and (yield from self.skillbook.Paragon.Leadership.Angelic_Protection(health_threshold=0.30)):
             return True
 
-        if self.IsSkillEquipped(Theres_Nothing_to_Fear_ID) and (yield from self.skills.Any.NoAttribute.Theres_Nothing_to_Fear()):
+        # Defensive shouts first - they are the reason the build is taken, and
+        # they are also the bar's energy engine, since Leadership refunds energy
+        # per ally a shout or chant affects.
+        if self.IsSkillEquipped(Theres_Nothing_to_Fear_ID) and (yield from self.skillbook.Any.NoAttribute.Theres_Nothing_to_Fear()):
             return True
 
-        if self.IsSkillEquipped(For_Great_Justice_ID) and (yield from self.skills.Warrior.NoAttribute.For_Great_Justice()):
+        # Save Yourselves outranks the skills that charge it: when it is already
+        # charged, spending the tick on an enabler instead delays the single
+        # biggest mitigation on the bar. When it is not charged its adrenaline
+        # check fails for free, and the enablers below run on the same tick's
+        # next pass.
+        if self.IsSkillEquipped(Save_Yourselves_kurzick_ID) and (yield from self.skillbook.Any.NoAttribute.Save_Yourselves_kurzick()):
             return True
 
-        if self.IsSkillEquipped(Make_Your_Time_ID) and (yield from self.skills.Paragon.Leadership.Make_Your_Time()):
+        if self.IsSkillEquipped(Save_Yourselves_luxon_ID) and (yield from self.skillbook.Any.NoAttribute.Save_Yourselves_luxon()):
             return True
 
-        if self.IsSkillEquipped(Stand_Your_Ground_ID) and (yield from self.skills.Paragon.Command.Stand_Your_Ground()):
+        if self.IsSkillEquipped(Stand_Your_Ground_ID) and (yield from self.skillbook.Paragon.Command.Stand_Your_Ground()):
             return True
 
-        if self.IsSkillEquipped(Cant_Touch_This_ID) and (yield from self.skills.Paragon.Command.Cant_Touch_This()):
+        if self.IsSkillEquipped(Never_Surrender_ID) and (yield from self.skillbook.Paragon.Motivation.Never_Surrender()):
             return True
 
-        if self.IsSkillEquipped(Never_Surrender_ID) and (yield from self.skills.Paragon.Motivation.Never_Surrender()):
+        # min_remaining_ms=0: the helper's default lets it recast with 1.5s
+        # still on the clock, which on this bar would throw away a refrain
+        # renewal every single time.
+        if self.IsSkillEquipped(Cant_Touch_This_ID) and (yield from self.skillbook.Paragon.Command.Cant_Touch_This(min_remaining_ms=0)):
             return True
 
-        if self.IsSkillEquipped(Blazing_Finale_ID) and (yield from self.skills.Paragon.Motivation.Blazing_Finale()):
+        if self.IsSkillEquipped(Protectors_Defense_ID) and (yield from self.skillbook.Warrior.NoAttribute.Protectors_Defense()):
             return True
 
-        if self.IsSkillEquipped(Protectors_Defense_ID) and (yield from self.skills.Warrior.NoAttribute.Protectors_Defense()):
+        # Adrenaline enablers, below the payload they exist to charge.
+        if self.IsSkillEquipped(Make_Your_Time_ID) and (yield from self.skillbook.Paragon.Leadership.Make_Your_Time()):
             return True
 
-        if self.IsSkillEquipped(Ebon_Vanguard_Assassin_Support_ID) and (yield from self.skills.Any.PvE.Ebon_Vanguard_Assassin_Support()):
+        if self.IsSkillEquipped(For_Great_Justice_ID) and (yield from self.skillbook.Warrior.NoAttribute.For_Great_Justice()):
             return True
 
-        if self.IsSkillEquipped(Ebon_Battle_Standard_of_Wisdom_ID) and (yield from self.skills.Any.NoAttribute.Ebon_Battle_Standard_of_Wisdom()):
+        if self.IsSkillEquipped(To_the_Limit_ID) and (yield from self.skillbook.Warrior.Tactics.To_the_Limit()):
             return True
 
-        if self.IsSkillEquipped(Mighty_Throw_ID) and (yield from self.skills.Paragon.SpearMastery.Mighty_Throw()):
+        # Offensive party support. "Go for the Eyes!" comes first because
+        # Vicious Attack below waits on it.
+        if self.IsSkillEquipped(Go_for_the_Eyes_ID) and (yield from self.skillbook.Paragon.Command.Go_for_the_Eyes()):
+            return True
+
+        if self.IsSkillEquipped(Find_Their_Weakness_ID) and (yield from self.skillbook.Paragon.Command.Find_Their_Weakness()):
+            return True
+
+        if self.IsSkillEquipped(Lyric_of_Zeal_ID) and (yield from self.skillbook.Paragon.Motivation.Lyric_of_Zeal()):
+            return True
+
+        # PvE slot.
+        if self.IsSkillEquipped(Ebon_Vanguard_Assassin_Support_ID) and (yield from self.skillbook.Any.PvE.Ebon_Vanguard_Assassin_Support()):
+            return True
+
+        if self.IsSkillEquipped(Ebon_Battle_Standard_of_Honor_ID) and (yield from self.skillbook.Any.NoAttribute.Ebon_Battle_Standard_of_Honor()):
+            return True
+
+        if self.IsSkillEquipped(Ebon_Battle_Standard_of_Wisdom_ID) and (yield from self.skillbook.Any.NoAttribute.Ebon_Battle_Standard_of_Wisdom()):
+            return True
+
+        if self.IsSkillEquipped(Great_Dwarf_Weapon_ID) and (yield from self.skillbook.Any.NoAttribute.Great_Dwarf_Weapon()):
+            return True
+
+        if self.IsSkillEquipped(Breath_of_the_Great_Dwarf_ID) and (yield from self.skillbook.Any.NoAttribute.Breath_of_the_Great_Dwarf()):
+            return True
+
+        if self.IsSkillEquipped(You_Move_Like_a_Dwarf_ID) and (yield from self.skillbook.Any.NoAttribute.You_Move_Like_a_Dwarf()):
+            return True
+
+        if self.IsSkillEquipped(Finish_Him_ID) and (yield from self.skillbook.Any.NoAttribute.Finish_Him()):
+            return True
+
+        # Mid-fight top-up: allies who died and were resurrected have lost their
+        # echoes. Below everything urgent, above filler.
+        if (yield from self._run_refrain_spreading()):
+            return True
+
+        if (yield from self._run_spear_attacks()):
             return True
 
         if (yield from self.AutoAttack()):
             return True
 
-        yield
+        return False
+
+    def _run_spear_attacks(self):
+        """Spear chain, ordered by what the current situation is worth.
+
+        Spear of Redemption jumps the queue while we are blinded: a blinded
+        attack misses, and the miss is what strips the Blindness - so the skill
+        is worth more as a condition removal than as damage.
+
+        Vicious Attack then outranks Mighty Throw, despite Mighty Throw hitting
+        harder. Its gate only passes while "Go for the Eyes!" is up, and that
+        shout buffs the next attack only - whichever spear skill goes first
+        spends the charge. A near-guaranteed Deep Wound is worth more than the
+        damage difference, so Vicious Attack should be the one that spends it.
+        When "Go for the Eyes!" is not on the bar the gate is inert and this is
+        simply the cheaper attack going first.
+        """
+        has_spear_of_redemption = self.IsSkillEquipped(Spear_of_Redemption_ID)
+        # Kept separate from the equipment check: folding the two together makes
+        # a blinded Paragon read as "not blinded" on every bar that does not
+        # carry the answer to it, which is the one case a future caller reading
+        # this flag would most need it to be right.
+        is_blinded = Routines.Checks.Agents.HasEffect(Player.GetAgentID(), Blind_ID)
+
+        if has_spear_of_redemption and is_blinded and (
+            yield from self.skillbook.Paragon.SpearMastery.Spear_of_Redemption()
+        ):
+            return True
+
+        # Spear of Redemption above is the only attack worth throwing blind,
+        # because its miss is the point. Every other attack skill would be spent
+        # and put on full recharge for a swing that almost certainly misses, so
+        # once it has had its chance - unequipped, or recharging - stop here and
+        # let the free auto-attack take the miss instead.
+        if is_blinded:
+            return False
+
+        if self.IsSkillEquipped(Vicious_Attack_ID) and (
+            yield from self.skillbook.Paragon.SpearMastery.Vicious_Attack(require_critical_buff=True)
+        ):
+            return True
+
+        if self.IsSkillEquipped(Mighty_Throw_ID) and (yield from self.skillbook.Paragon.SpearMastery.Mighty_Throw()):
+            return True
+
+        if has_spear_of_redemption and (yield from self.skillbook.Paragon.SpearMastery.Spear_of_Redemption()):
+            return True
+
+        return False
+
+    def _run_local_skill_logic(self):
+        if not Routines.Checks.Skills.CanCast():
+            yield from Routines.Yield.wait(100)
+            return False
+
+        if (yield from self._run_upkeep()):
+            return True
+
+        if not self.IsInAggro():
+            return False
+
+        if (yield from self._run_combat()):
+            return True
+
+        return False

--- a/Py4GWCoreLib/Builds/Skills/any/NoAttribute.py
+++ b/Py4GWCoreLib/Builds/Skills/any/NoAttribute.py
@@ -17,8 +17,12 @@ __all__ = ["NoAttribute"]
 class NoAttribute:
     def __init__(self, build: BuildMgr) -> None:
         self.build: BuildMgr = build
-        self._save_yourselves_throttle: ThrottledTimer = ThrottledTimer(4000)
-        self._save_yourselves_throttle.Stop()
+        # Per-skill, not one shared timer: these party shouts are alternatives
+        # to each other, and a single timer meant whichever one the rotation
+        # happened to evaluate first locked out the others for its whole window
+        # - "There's Nothing to Fear!" would shut out a charged "Save
+        # Yourselves!" for roughly the entire 4-6s the +100 armor would have run.
+        self._party_shout_throttles: dict[int, ThrottledTimer] = {}
         self._iau_last_kd_ms: int = 0
         self._iau_recent_kd_window_ms: int = 1500
 
@@ -519,7 +523,12 @@ class NoAttribute:
     ) -> BuildCoroutine:
         player_agent_id = Player.GetAgentID()
 
-        if not (self._save_yourselves_throttle.IsStopped() or self._save_yourselves_throttle.IsExpired()):
+        throttle = self._party_shout_throttles.get(skill_id)
+        if throttle is None:
+            throttle = ThrottledTimer(4000)
+            throttle.Stop()
+            self._party_shout_throttles[skill_id] = throttle
+        if not (throttle.IsStopped() or throttle.IsExpired()):
             return False
         if not self.build.IsSkillEquipped(skill_id):
             return False
@@ -542,7 +551,7 @@ class NoAttribute:
             aftercast_delay=250,
         )
         if cast_result:
-            self._save_yourselves_throttle.Reset()
+            throttle.Reset()
         return cast_result
 
     def _get_owned_core_spirits(

--- a/Py4GWCoreLib/Builds/Skills/paragon/Command.py
+++ b/Py4GWCoreLib/Builds/Skills/paragon/Command.py
@@ -16,8 +16,32 @@ class Command:
     def __init__(self, build: BuildMgr) -> None:
         self.build: BuildMgr = build
 
+    #region B
+    def Bladeturn_Refrain(self, *, max_target_range: float | None = None) -> BuildCoroutine:
+        return (yield from self.build.SpreadEchoToAlly(
+            Skill.GetID("Bladeturn_Refrain"),
+            max_range=max_target_range,
+        ))
+    #endregion
+
     #region C
-    def Cant_Touch_This(self) -> BuildCoroutine:
+    def Cant_Touch_This(self, *, min_remaining_ms: int = 1500) -> BuildCoroutine:
+        """Anti-touch party shout.
+
+        min_remaining_ms is how much of the running shout we are willing to
+        throw away by recasting early. Callers maintaining refrains should
+        pass 0.
+
+        Inferred, not confirmed in an injected client: a shout replaced before
+        it expires is believed not to fire the "a chant or shout ends" trigger
+        that reapplies an echo, so recasting early would silently skip a refrain
+        renewal for the whole party. What the shipped data actually states is
+        only the positive half - skill_descriptions.json describes a refrain as
+        renewed "whenever a chant or shout ends on that ally". The rest comes
+        from the PvX build notes. Every "let it expire first" guard on the
+        Paragon refrain bar rests on this, so it is the one assumption to settle
+        first if the rotation misbehaves in game.
+        """
         cant_touch_this_id: int = Skill.GetID("Cant_Touch_This")
         player_agent_id = Player.GetAgentID()
 
@@ -27,12 +51,101 @@ class Command:
             return False
 
         if Routines.Checks.Agents.HasEffect(player_agent_id, cant_touch_this_id):
+            if min_remaining_ms <= 0:
+                # Presence is authoritative, the remaining time is not:
+                # GetEffectTimeRemaining only scans the effect list while
+                # HasEffect also accepts the buff list, so a shout reported as a
+                # buff reads 0 here. A caller asking us never to clip the shout
+                # would then clip it on every recharge - the exact failure this
+                # parameter exists to prevent.
+                return False
             remaining_ms = int(GLOBAL_CACHE.Effects.GetEffectTimeRemaining(player_agent_id, cant_touch_this_id) or 0)
-            if remaining_ms > 1500:
+            if remaining_ms > min_remaining_ms:
                 return False
 
         return (yield from self.build.CastSkillID(
             skill_id=cant_touch_this_id,
+            log=False,
+            aftercast_delay=250,
+        ))
+    #endregion
+
+    #region F
+    def Fall_Back(self) -> BuildCoroutine:
+        """Party-wide out-of-combat run speed.
+
+        Ends on the affected ally's next attack, so it is only worth casting
+        while the party is travelling. "Incoming!" is the same non-stacking
+        speed buff, and BuildMgr does not enforce the CustomSkill
+        Conditions.SharedEffects link, so the overlap is checked here.
+        """
+        fall_back_id: int = Skill.GetID("Fall_Back")
+        incoming_id: int = Skill.GetID("Incoming")
+        player_agent_id = Player.GetAgentID()
+
+        if not self.build.IsSkillEquipped(fall_back_id):
+            return False
+        if self.build.IsInAggro() or self.build.IsCloseToAggro():
+            return False
+        if Routines.Checks.Agents.HasEffect(player_agent_id, fall_back_id):
+            return False
+        if Routines.Checks.Agents.HasEffect(player_agent_id, incoming_id):
+            return False
+
+        return (yield from self.build.CastSkillID(
+            skill_id=fall_back_id,
+            log=False,
+            aftercast_delay=250,
+        ))
+
+    def Find_Their_Weakness(self) -> BuildCoroutine:
+        """Hands the next attack of one martial ally a big bonus plus Deep Wound."""
+        find_their_weakness_id: int = Skill.GetID("Find_Their_Weakness")
+        find_their_weakness = self.build.GetCustomSkill(find_their_weakness_id)
+
+        if not self.build.IsInAggro():
+            return False
+        # Before resolving an ally: that walks the party several times and this
+        # runs every tick, while the chant is on recharge for most of them.
+        if not self.build.CanCastSkillID(find_their_weakness_id):
+            return False
+
+        target_agent_id = self.build.ResolveAllyTargetInRange(
+            find_their_weakness_id,
+            find_their_weakness,
+        )
+        if not target_agent_id:
+            return False
+
+        return (yield from self.build.CastSkillIDAndRestoreTarget(
+            skill_id=find_their_weakness_id,
+            target_agent_id=target_agent_id,
+            log=False,
+            aftercast_delay=250,
+        ))
+    #endregion
+
+    #region G
+    def Go_for_the_Eyes(self) -> BuildCoroutine:
+        """Party-wide critical hit chance, and the bar's cheapest energy engine.
+
+        Leadership refunds energy per ally a shout affects, so this pays for
+        itself several times over in a full party. Guarded on our own copy
+        expiring rather than on recharge: replacing a running shout skips the
+        refrain renewal that fires when a shout ends.
+        """
+        go_for_the_eyes_id: int = Skill.GetID("Go_for_the_Eyes")
+        player_agent_id = Player.GetAgentID()
+
+        if not self.build.IsSkillEquipped(go_for_the_eyes_id):
+            return False
+        if not self.build.IsInAggro():
+            return False
+        if Routines.Checks.Agents.HasEffect(player_agent_id, go_for_the_eyes_id):
+            return False
+
+        return (yield from self.build.CastSkillID(
+            skill_id=go_for_the_eyes_id,
             log=False,
             aftercast_delay=250,
         ))

--- a/Py4GWCoreLib/Builds/Skills/paragon/Leadership.py
+++ b/Py4GWCoreLib/Builds/Skills/paragon/Leadership.py
@@ -106,6 +106,14 @@ class Leadership:
         ))
 
     def Aggressive_Refrain(self) -> BuildCoroutine:
+        """Apply the 25% IAS echo once; the bar's shouts keep it up from there.
+
+        Not gated on aggro. Aggressive Refrain is reapplied every time a chant
+        or shout ends on us, so on any bar carrying shouts it never drops once
+        it lands - which means holding it back until combat buys nothing. The
+        -20 armor is permanent either way, and waiting only costs us the attack
+        speed for the opening of every fight.
+        """
         aggressive_refrain_id: int = Skill.GetID("Aggressive_Refrain")
         player_agent_id = Player.GetAgentID()
 

--- a/Py4GWCoreLib/Builds/Skills/paragon/Motivation.py
+++ b/Py4GWCoreLib/Builds/Skills/paragon/Motivation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from Py4GWCoreLib.BuildMgr import BuildCoroutine
-from Py4GWCoreLib import Range
+from Py4GWCoreLib import Player, Range, Routines
 from Py4GWCoreLib.Skill import Skill
 
 if TYPE_CHECKING:
@@ -17,46 +17,43 @@ class Motivation:
         self.build: BuildMgr = build
 
     #region B
-    def Blazing_Finale(self) -> BuildCoroutine:
-        blazing_finale_id: int = Skill.GetID("Blazing_Finale")
-        blazing_finale = self.build.GetCustomSkill(blazing_finale_id)
+    def Blazing_Finale(self, *, max_target_range: float | None = None) -> BuildCoroutine:
+        return (yield from self.build.SpreadEchoToAlly(Skill.GetID("Blazing_Finale"), max_range=max_target_range))
 
-        if not self.build.IsSkillEquipped(blazing_finale_id):
-            return False
+    def Burning_Refrain(self, *, max_target_range: float | None = None) -> BuildCoroutine:
+        return (yield from self.build.SpreadEchoToAlly(Skill.GetID("Burning_Refrain"), max_range=max_target_range))
+    #endregion
 
-        target_agent_id = self.build.ResolveAllyTarget(
-            blazing_finale_id,
-            blazing_finale,
-        )
-        if not target_agent_id:
-            return False
-
-        return (yield from self.build.CastSkillIDAndRestoreTarget(
-            skill_id=blazing_finale_id,
-            target_agent_id=target_agent_id,
-            log=False,
-            aftercast_delay=250,
-        ))
+    #region E
+    def Energizing_Finale(self, *, max_target_range: float | None = None) -> BuildCoroutine:
+        return (yield from self.build.SpreadEchoToAlly(Skill.GetID("Energizing_Finale"), max_range=max_target_range))
     #endregion
 
     #region H
-    def Hasty_Refrain(self) -> BuildCoroutine:
-        hasty_refrain_id: int = Skill.GetID("Hasty_Refrain")
-        hasty_refrain = self.build.GetCustomSkill(hasty_refrain_id)
+    def Hasty_Refrain(self, *, max_target_range: float | None = None) -> BuildCoroutine:
+        return (yield from self.build.SpreadEchoToAlly(Skill.GetID("Hasty_Refrain"), max_range=max_target_range))
+    #endregion
 
-        if not self.build.IsSkillEquipped(hasty_refrain_id):
+    #region L
+    def Lyric_of_Zeal(self) -> BuildCoroutine:
+        """Party-wide energy on the next signet cast.
+
+        A self-targeted chant, so it also counts as a shout/chant ending on us
+        later - which is another refrain renewal tick. Guarded on our own copy
+        having expired so we never replace a running chant.
+        """
+        lyric_of_zeal_id: int = Skill.GetID("Lyric_of_Zeal")
+        player_agent_id = Player.GetAgentID()
+
+        if not self.build.IsSkillEquipped(lyric_of_zeal_id):
+            return False
+        if not (self.build.IsInAggro() or self.build.IsCloseToAggro()):
+            return False
+        if Routines.Checks.Agents.HasEffect(player_agent_id, lyric_of_zeal_id):
             return False
 
-        target_agent_id = self.build.ResolveAllyTarget(
-            hasty_refrain_id,
-            hasty_refrain,
-        )
-        if not target_agent_id:
-            return False
-
-        return (yield from self.build.CastSkillIDAndRestoreTarget(
-            skill_id=hasty_refrain_id,
-            target_agent_id=target_agent_id,
+        return (yield from self.build.CastSkillID(
+            skill_id=lyric_of_zeal_id,
             log=False,
             aftercast_delay=250,
         ))
@@ -95,13 +92,35 @@ class Motivation:
 
         if not self.build.IsSkillEquipped(never_surrender_id):
             return False
+        # Before the two party scans below. Each HasEffect call rebuilds that
+        # agent's buff and effect lists from native, so leaving this ungated
+        # pays for the whole party every frame we are in aggro - including the
+        # long stretches where the shout is simply recharging.
+        if not self.build.CanCastSkillID(never_surrender_id):
+            return False
 
-        ally_array = GetAllAlliesArray(Range.Earshot.value)
+        nearby_allies = GetAllAlliesArray(Range.Earshot.value)
         ally_array = AgentArray.Filter.ByCondition(
-            ally_array,
-            lambda agent_id: Agent.IsAlive(agent_id) and Agent.GetHealth(agent_id) < 0.70,
+            nearby_allies,
+            # 75%, matching the skill: it grants regeneration to party members
+            # below that mark, so a tighter filter withholds the shout in the
+            # 70-75% band where it would in fact have helped everyone counted.
+            lambda agent_id: Agent.IsAlive(agent_id) and Agent.GetHealth(agent_id) < 0.75,
         )
         if len(ally_array or []) < 2:
+            return False
+
+        # Let the running shout expire before recasting - see the inferred
+        # renewal mechanic documented on Command.Cant_Touch_This. The check has
+        # to look at an ally rather than at us, because this shout only lands on
+        # party members below 75% health, and the caster usually is not one of
+        # them, so a self-check would be inert exactly when it matters.
+        #
+        # Checked over every nearby ally rather than the sub-75% set above: the
+        # shout keeps running on allies who have since been healed past that
+        # threshold, and they are exactly the ones a "is a copy still up?" test
+        # must not lose sight of.
+        if any(Routines.Checks.Agents.HasEffect(agent_id, never_surrender_id) for agent_id in (nearby_allies or [])):
             return False
 
         return (yield from self.build.CastSkillID(

--- a/Py4GWCoreLib/Builds/Skills/paragon/SpearMastery.py
+++ b/Py4GWCoreLib/Builds/Skills/paragon/SpearMastery.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from Py4GWCoreLib import Routines
 from Py4GWCoreLib.BuildMgr import BuildCoroutine
+from Py4GWCoreLib.Player import Player
 from Py4GWCoreLib.Skill import Skill
 
 if TYPE_CHECKING:
@@ -38,3 +40,52 @@ class SpearMastery:
         ))
     #endregion
 
+    #region S
+    def Spear_of_Redemption(self) -> BuildCoroutine:
+        """Spear attack that strips a condition from us when it misses.
+
+        Worth throwing while blinded, which is the reason PvX carries it: a
+        blinded attack misses, and the miss is what removes the Blindness.
+        """
+        spear_of_redemption_id: int = Skill.GetID("Spear_of_Redemption")
+        target_agent_id = self._resolve_spear_target(spear_of_redemption_id)
+        if not target_agent_id:
+            return False
+
+        return (yield from self.build.CastSkillIDAndRestoreTarget(
+            skill_id=spear_of_redemption_id,
+            target_agent_id=target_agent_id,
+            log=False,
+            aftercast_delay=250,
+        ))
+    #endregion
+
+    #region V
+    def Vicious_Attack(self, *, require_critical_buff: bool = False) -> BuildCoroutine:
+        """Spear attack that applies Deep Wound on a critical hit.
+
+        With require_critical_buff set, it is held until "Go for the Eyes!" is
+        up on us - that shout is what turns the conditional Deep Wound into a
+        reliable one, and it is why PvX pairs the two.
+        """
+        vicious_attack_id: int = Skill.GetID("Vicious_Attack")
+
+        if require_critical_buff:
+            go_for_the_eyes_id: int = Skill.GetID("Go_for_the_Eyes")
+            if self.build.IsSkillEquipped(go_for_the_eyes_id) and not Routines.Checks.Agents.HasEffect(
+                Player.GetAgentID(),
+                go_for_the_eyes_id,
+            ):
+                return False
+
+        target_agent_id = self._resolve_spear_target(vicious_attack_id)
+        if not target_agent_id:
+            return False
+
+        return (yield from self.build.CastSkillIDAndRestoreTarget(
+            skill_id=vicious_attack_id,
+            target_agent_id=target_agent_id,
+            log=False,
+            aftercast_delay=250,
+        ))
+    #endregion

--- a/Py4GWCoreLib/Builds/Skills/warrior/Tactics.py
+++ b/Py4GWCoreLib/Builds/Skills/warrior/Tactics.py
@@ -2,10 +2,43 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from Py4GWCoreLib import Player, Routines
+from Py4GWCoreLib.BuildMgr import BuildCoroutine
+from Py4GWCoreLib.Skill import Skill
+
 if TYPE_CHECKING:
     from Py4GWCoreLib.BuildMgr import BuildMgr
+
+__all__ = ["Tactics"]
+
 
 class Tactics:
     def __init__(self, build: BuildMgr) -> None:
         self.build: BuildMgr = build
 
+    #region T
+    def To_the_Limit(self) -> BuildCoroutine:
+        """Adrenaline generator: one strike per foe in earshot, plus max Health.
+
+        Its whole value is the initial burst, which scales with how many foes
+        are around, so it is held until we are actually in the fight rather than
+        spent on the approach. Guarded on our own copy expiring: it is a shout,
+        and recasting one before it ends skips the refrain renewal that fires
+        when a shout ends on an ally.
+        """
+        to_the_limit_id: int = Skill.GetID("To_the_Limit")
+        player_agent_id = Player.GetAgentID()
+
+        if not self.build.IsSkillEquipped(to_the_limit_id):
+            return False
+        if not self.build.IsInAggro():
+            return False
+        if Routines.Checks.Agents.HasEffect(player_agent_id, to_the_limit_id):
+            return False
+
+        return (yield from self.build.CastSkillID(
+            skill_id=to_the_limit_id,
+            log=False,
+            aftercast_delay=250,
+        ))
+    #endregion


### PR DESCRIPTION
Builds on @Wellwisher533's f714b40a4 "Improve HeroAI Paragon refrain rotation"
to finish porting PvX [Build:P/any Heroic Refrain Spear](https://gwpvx.fandom.com/wiki/Build:P/any_Heroic_Refrain_Spear)
and its two P/W variants.

**This is additive on top of that commit.** `Heroic_Refrain`, `Mending_Refrain`,
`Mighty_Throw`, `_resolve_spear_target` and `Anthem_of_Flame` are left exactly
as it wrote them, including Anthem of Flame's slot in the pre-aggro upkeep
block. `Leadership.py` and `SpearMastery.py` have **zero deleted lines** — the
new spear skills reuse the existing `_resolve_spear_target` rather than
replacing it.

## New skillbook helpers

| Attribute | Added |
|---|---|
| SpearMastery | Spear of Redemption, Vicious Attack |
| Command | Go for the Eyes, Find Their Weakness, Fall Back, Bladeturn Refrain |
| Motivation | Lyric of Zeal, Energizing Finale, Burning Refrain |
| warrior Tactics | To the Limit (the module was an empty stub) |

Vicious Attack also gains the `CustomSkill` registration it was missing —
without it the `RequireWeapon = "Spear"` gate did not exist, so the engine would
issue it on a staff.

## Earshot clamp for refrain spreading

`BuildMgr` gains `ResolveAllyTargetInRange` and `SpreadEchoToAlly`. A refrain is
renewed only when a chant or shout *ends* on its holder, and those reach
earshot, while ally targeting resolves to spellcast range. A refrain handed to
someone further out can therefore never be renewed: it expires and is paid for
again every recharge.

The clamp narrows the **candidate pool** rather than vetting the resolved
winner. That distinction matters — ally selection ranks by lowest health, so a
straggler outside earshot is usually also the hurt one, would be picked first,
rejected, and picked again on every tick, blocking the allies standing next to
us. The `HeroAI/targeting.py` selectors gained a `distance` parameter defaulting
to the value they previously hardcoded, so every existing caller is unchanged.

## Rotation

Split into upkeep / refrain-spreading / combat / spear phases, so the secondary
echoes stop outranking the defensive shouts once a fight starts. Every declared
skill is driven — declaring one masks it out of the HeroAI fallback, so a
declared skill the build never casts is a skill nobody casts.

## Smaller fixes

- The single 4s throttle shared by `"There's Nothing to Fear!"` and both
  `"Save Yourselves!"` variants is now per skill. Previously whichever the
  rotation evaluated first locked out the others for roughly the entire window
  the +100 armor would have run.
- `"Never Surrender!"` gates on `CanCastSkillID` before scanning the party —
  each `HasEffect` rebuilds that agent's buff and effect lists from native, so
  the unguarded scan paid for the whole party every frame, including while the
  shout was recharging. It also now waits for its own copy to expire and
  matches the skill's 75% threshold rather than 70%.
- Blindness stops the spear skills rather than only reordering them: only Spear
  of Redemption is worth throwing blind, because its miss is the point.

## One assumption, flagged

Several "let it expire first" guards rest on the idea that a shout *replaced*
before it expires does not fire the refrain-renewal trigger. The shipped skill
data states only the positive half — a refrain is renewed "whenever a chant or
shout ends on that ally" — and the rest comes from the PvX build notes. It is
**inferred, not confirmed in an injected client**, and is labelled as such on
`Command.Cant_Touch_This`. It is the first thing to settle if the rotation
misbehaves in play.

## Verification

`python -m py_compile` passes on all 10 files; all 35 declared skills have call
sites. **Not verified in an injected client** — the repo cannot be imported
outside the game, so this is source reasoning plus compile checks, not runtime
proof.
