### PR TITLE
Persist HeroAI build contract ticks in the existing owner

### DIFF
--- a/Py4GWCoreLib/Builds/Any/HeroAI.py
+++ b/Py4GWCoreLib/Builds/Any/HeroAI.py
@@ -1,3 +1,6 @@
+from collections.abc import Iterator
+from typing import Any
+
 from Py4GWCoreLib import Agent, Map, Player, Profession, Routines
 from Py4GWCoreLib import BuildMgr
 from Py4GWCoreLib.BuildMgr import BuildRegistry
@@ -13,6 +16,9 @@ class HeroAI_Build(BuildMgr):
         )
         self._cached_data = cached_data
         self._standalone_fallback = standalone_fallback
+        self._tick_coroutine: Iterator[Any] | None = None
+        self._tick_phase: bool | None = None
+        self._tick_contract_signature: tuple[int, ...] | None = None
         if match_only:
             self._build_registry = None
             self._contract_map_signature = None
@@ -62,7 +68,23 @@ class HeroAI_Build(BuildMgr):
         self._contract_signature = None
         self._contract_build = None
 
+    def ResetTickExecution(self) -> None:
+        coroutine = self._tick_coroutine
+        self._tick_coroutine = None
+        self._tick_phase = None
+        self._tick_contract_signature = None
+        if coroutine is None:
+            return
+
+        close = getattr(coroutine, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass
+
     def ClearBuildContract(self) -> None:
+        self.ResetTickExecution()
         self._reset_contract()
 
     def EnsureBuildContract(self, cached_data=None):
@@ -211,6 +233,30 @@ class HeroAI_Build(BuildMgr):
             yield from self.ProcessCombat()
         else:
             yield from self.ProcessOOC()
+
+    def Tick(self, is_in_combat: bool):
+        """Advance the selected contract once while preserving its coroutine."""
+        resolved_phase = bool(is_in_combat)
+        contract_signature = self._get_contract_signature() if Map.IsExplorable() else None
+
+        if self._tick_coroutine is not None and (
+            self._tick_phase != resolved_phase
+            or self._tick_contract_signature != contract_signature
+        ):
+            self.ResetTickExecution()
+
+        if self._tick_coroutine is None:
+            self._tick_phase = resolved_phase
+            self._tick_contract_signature = contract_signature
+            self._tick_coroutine = super().Tick(resolved_phase)
+
+        try:
+            next(self._tick_coroutine)
+        except StopIteration:
+            self._tick_coroutine = None
+            self._tick_phase = None
+            self._tick_contract_signature = None
+        yield
 
 
 HeroAI = HeroAI_Build

--- a/Py4GWCoreLib/HeroAI/headless_tree.py
+++ b/Py4GWCoreLib/HeroAI/headless_tree.py
@@ -32,7 +32,6 @@ class HeroAIHeadlessTree:
         self.cached_data = cached_data or CacheData()
         self.heroai_build = heroai_build or HeroAI_Build(self.cached_data)
         Settings().AutoCallTargets = True
-        self._build_contract_map_signature: tuple[int, int, int, int] | None = None
         self._loot_throttle_check = ThrottledTimer(250)
         self._looting_node: BehaviorTree.ActionNode | None = None
         self._status_selector: BehaviorTree.SelectorNode | None = None
@@ -139,12 +138,14 @@ class HeroAIHeadlessTree:
     def _handle_out_of_combat(self) -> bool:
         options = self.cached_data.account_options
         if not options or not options.Combat:
+            self.heroai_build.ResetTickExecution()
             return False
 
         if self.cached_data.IsHeadlessCombatPauseActive():
             return False
 
         if is_follow_recovery_active(self.cached_data, self._follow_state):
+            self.heroai_build.ResetTickExecution()
             return False
 
         player_agent_id = Player.GetAgentID()
@@ -152,22 +153,24 @@ class HeroAIHeadlessTree:
             return False
 
         self.heroai_build.set_cached_data(self.cached_data)
-        next(self.heroai_build.ProcessOOC(), None)
+        next(self.heroai_build.Tick(is_in_combat=False), None)
         return self.heroai_build.DidTickSucceed()
 
     def _handle_combat(self) -> bool:
         options = self.cached_data.account_options
         if not options or not options.Combat:
+            self.heroai_build.ResetTickExecution()
             return False
 
         if is_follow_recovery_active(self.cached_data, self._follow_state):
+            self.heroai_build.ResetTickExecution()
             return False
 
         if not self.cached_data.IsHeadlessCombatPauseActive():
             return False
 
         self.heroai_build.set_cached_data(self.cached_data)
-        next(self.heroai_build.ProcessCombat(), None)
+        next(self.heroai_build.Tick(is_in_combat=True), None)
         return self.heroai_build.DidTickSucceed()
 
     def _distance_to_destination(self) -> float:
@@ -214,31 +217,25 @@ class HeroAIHeadlessTree:
     def initialize(self) -> bool:
         if not Routines.Checks.Map.MapValid():
             self.heroai_build.ClearBuildContract()
-            self._build_contract_map_signature = None
             return False
 
         if not GLOBAL_CACHE.Party.IsPartyLoaded():
+            self.heroai_build.ResetTickExecution()
             return False
 
         if not Map.IsExplorable():
             self.heroai_build.ClearBuildContract()
-            self._build_contract_map_signature = None
             return False
 
         if Map.IsInCinematic():
+            self.heroai_build.ResetTickExecution()
             return False
 
-        self.heroai_build.set_cached_data(self.cached_data)
-        map_signature = (
-            int(Map.GetMapID()),
-            int(Map.GetRegion()[0]),
-            int(Map.GetDistrict()),
-            int(Map.GetLanguage()[0]),
-        )
-        if self._build_contract_map_signature != map_signature:
-            self.heroai_build.EnsureBuildContract(self.cached_data)
-            self._build_contract_map_signature = map_signature
+        player_agent_id = Player.GetAgentID()
+        if not Agent.IsAlive(player_agent_id) or Agent.IsKnockedDown(player_agent_id):
+            self.heroai_build.ResetTickExecution()
 
+        self.heroai_build.set_cached_data(self.cached_data)
         self.cached_data.UpdateCombat()
         return True
 
@@ -262,7 +259,6 @@ class HeroAIHeadlessTree:
     def reset(self) -> None:
         self.tree.reset()
         self.heroai_build.ClearBuildContract()
-        self._build_contract_map_signature = None
         self._follow_state = FollowExecutionState()
 
     def _build_tree(self):

--- a/Widgets/Automation/Multiboxing/HeroAI.py
+++ b/Widgets/Automation/Multiboxing/HeroAI.py
@@ -38,7 +38,6 @@ LOOT_THROTTLE_CHECK = ThrottledTimer(250)
 cached_data = CacheData()
 heroai_build = HeroAI_Build(cached_data)
 map_quads : list[Map.Pathing.Quad] = []
-build_contract_map_signature: tuple[int, int, int, int] | None = None
 #region Looting
 def LootingNode(cached_data: CacheData)-> BehaviorTree.NodeState:
     options = cached_data.account_options
@@ -92,12 +91,14 @@ def HandleOutOfCombat(cached_data: CacheData):
     options = cached_data.account_options
     
     if not options or not options.Combat:  # halt operation if combat is disabled
+        heroai_build.ResetTickExecution()
         return False
     
     if cached_data.data.in_aggro:
         return False
 
     if is_follow_recovery_active(cached_data, follow_execution_state):
+        heroai_build.ResetTickExecution()
         return False
 
     player_agent_id = Player.GetAgentID()
@@ -105,23 +106,25 @@ def HandleOutOfCombat(cached_data: CacheData):
         return False
 
     heroai_build.set_cached_data(cached_data)
-    next(heroai_build.ProcessOOC(), None)
+    next(heroai_build.Tick(is_in_combat=False), None)
     return heroai_build.DidTickSucceed()
 
 def HandleCombat(cached_data: CacheData):
     options = cached_data.account_options
     
     if not options or not options.Combat:  # halt operation if combat is disabled
+        heroai_build.ResetTickExecution()
         return False
 
     if is_follow_recovery_active(cached_data, follow_execution_state):
+        heroai_build.ResetTickExecution()
         return False
     
     if not cached_data.data.in_aggro:
         return False
 
     heroai_build.set_cached_data(cached_data)
-    next(heroai_build.ProcessCombat(), None)
+    next(heroai_build.Tick(is_in_combat=True), None)
     return heroai_build.DidTickSucceed()
 
 
@@ -182,37 +185,29 @@ def handle_UI (cached_data: CacheData):
     HeroAI_BaseUI.DrawBuildMatchesWindow(cached_data)
     HeroAI_BaseUI.DrawFollowFormationsQuickWindow(cached_data)
    
-def initialize(cached_data: CacheData) -> bool:  
-    global build_contract_map_signature
-
+def initialize(cached_data: CacheData) -> bool:
     if not Routines.Checks.Map.MapValid():
         heroai_build.ClearBuildContract()
-        build_contract_map_signature = None
         return False
     
     if not GLOBAL_CACHE.Party.IsPartyLoaded():
+        heroai_build.ResetTickExecution()
         return False
         
     if not Map.IsExplorable():  # halt operation if not in explorable area
         heroai_build.ClearBuildContract()
-        build_contract_map_signature = None
         return False
 
     if Map.IsInCinematic():  # halt operation during cinematic
+        heroai_build.ResetTickExecution()
         return False
     
     HeroAI_BaseUI._process_flagging_runtime(cached_data)
     #HeroAI_FloatingWindows.draw_Targeting_floating_buttons(cached_data)     
     heroai_build.set_cached_data(cached_data)
-    map_signature = (
-        int(Map.GetMapID()),
-        int(Map.GetRegion()[0]),
-        int(Map.GetDistrict()),
-        int(Map.GetLanguage()[0]),
-    )
-    if build_contract_map_signature != map_signature:
-        heroai_build.EnsureBuildContract(cached_data)
-        build_contract_map_signature = map_signature
+    player_agent_id = Player.GetAgentID()
+    if not Agent.IsAlive(player_agent_id) or Agent.IsKnockedDown(player_agent_id):
+        heroai_build.ResetTickExecution()
     cached_data.UpdateCombat()
     return True
 
@@ -482,6 +477,7 @@ def minimal():
     draw_skip_cutscene_overlay()
 
 def on_enable():
+    heroai_build.ClearBuildContract()
     HeroAI_FloatingWindows.settings.reset()
     HeroAI_FloatingWindows.SETTINGS_THROTTLE.SetThrottleTime(50)
 


### PR DESCRIPTION
## Summary

- persist the active `BuildMgr.Tick(is_in_combat)` coroutine inside the existing `HeroAI_Build` owner and advance it once per frame
- close pending execution when the combat phase or build/map/skill signature changes, and when the contract is cleared
- route both headless HeroAI and the visible Multibox HeroAI widget through the same owner
- cancel pending execution at combat-disable, follow-recovery, unloaded-party, cinematic, death/knockdown, map, widget-enable, and explicit-reset boundaries
- remove the redundant caller-side contract preselection; `_run_contract` remains the single owner of contract selection, self-contract handling, tick-state reset, and result propagation

## Why

Both HeroAI callers created a fresh `ProcessOOC()` or `ProcessCombat()` generator every frame and advanced it once. Multi-yield build work therefore restarted instead of resuming. The previous version of this PR diagnosed that correctly but added a parallel contract runner. This rewrite fixes the generator lifetime in `HeroAI_Build`, where the contract loop already lives.

## Validation

- all three changed source files compile
- 5 local owner-lifecycle tests pass: same-phase resume, phase cancellation, signature cancellation, contract clear, and idempotent reset
- 6 existing Paragon phase-handler tests pass
- final audit finds no fresh `ProcessOOC`/`ProcessCombat` stepping in either HeroAI caller
- the owner-persistence behavior was previously validated in-game with the headless Heroic Refrain contract; this current source-only rewrite has been revalidated offline against current `main`

Local test artifacts and the superseded parallel runner are intentionally not included.