### PR TITLE
Keep Paragon refrain upkeep atomic across combat transitions

### DIFF
--- a/Examples and tests/tests/test_paragon_refrain_atomic_handlers.py
+++ b/Examples and tests/tests/test_paragon_refrain_atomic_handlers.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_PATH = (
+    ROOT
+    / "Py4GWCoreLib"
+    / "Builds"
+    / "Paragon"
+    / "P_W"
+    / "Defensive Refrain.py"
+)
+
+SKILL_IDS = {
+    name: index + 1
+    for index, name in enumerate(
+        (
+            "Heroic_Refrain",
+            "Mending_Refrain",
+            "Bladeturn_Refrain",
+            "Energizing_Finale",
+            "Burning_Refrain",
+            "Blazing_Finale",
+            "Hasty_Refrain",
+            "Aggressive_Refrain",
+            "Anthem_of_Flame",
+            "Theyre_on_Fire",
+            "Fall_Back",
+        )
+    )
+}
+
+
+class _ChecksSkills:
+    can_cast = True
+
+    @classmethod
+    def CanCast(cls):
+        return cls.can_cast
+
+
+class _Routines:
+    class Checks:
+        Skills = _ChecksSkills
+
+
+class _BuildMgr:
+    pass
+
+
+def _load_contract_class():
+    source = CONTRACT_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    class_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "Paragon_Refrain"
+    )
+    isolated = ast.Module(body=[class_node], type_ignores=[])
+    ast.fix_missing_locations(isolated)
+    namespace = {
+        "BuildMgr": _BuildMgr,
+        "Routines": _Routines,
+        "SkillsTemplate": object,
+        **{f"{name}_ID": skill_id for name, skill_id in SKILL_IDS.items()},
+    }
+    exec(compile(isolated, CONTRACT_PATH, "exec"), namespace)
+    return namespace["Paragon_Refrain"]
+
+
+ParagonRefrain = _load_contract_class()
+
+
+def _run(generator):
+    try:
+        while True:
+            next(generator)
+    except StopIteration as stop:
+        return stop.value
+
+
+class ParagonRefrainAtomicHandlerTests(unittest.TestCase):
+    def setUp(self):
+        _ChecksSkills.can_cast = True
+        self.events = []
+        self.build = object.__new__(ParagonRefrain)
+        self.build.IsInAggro = lambda: True
+        self.upkeep_result = True
+        self.combat_result = True
+
+        def upkeep():
+            if False:
+                yield
+            self.events.append("upkeep")
+            return self.upkeep_result
+
+        def combat():
+            if False:
+                yield
+            self.events.append("combat")
+            return self.combat_result
+
+        self.build._run_upkeep = upkeep
+        self.build._run_combat = combat
+
+    def test_ooc_starts_with_upkeep_on_each_fresh_tick(self):
+        self.assertTrue(_run(self.build._run_ooc()))
+        self.assertTrue(_run(self.build._run_ooc()))
+        self.assertEqual(self.events, ["upkeep", "upkeep"])
+
+    def test_ooc_to_combat_transition_does_not_lose_upkeep(self):
+        self.assertTrue(_run(self.build._run_ooc()))
+        self.assertTrue(_run(self.build._run_combat_phase()))
+        self.assertEqual(self.events, ["upkeep", "upkeep"])
+
+    def test_combat_work_runs_only_after_upkeep_has_nothing_to_do(self):
+        self.upkeep_result = False
+        self.assertTrue(_run(self.build._run_combat_phase()))
+        self.assertEqual(self.events, ["upkeep", "combat"])
+
+    def test_cannot_cast_returns_without_creating_a_waiting_continuation(self):
+        _ChecksSkills.can_cast = False
+        self.assertFalse(_run(self.build._run_ooc()))
+        self.assertFalse(_run(self.build._run_combat_phase()))
+        self.assertEqual(self.events, [])
+
+    def test_contract_registers_explicit_phase_handlers(self):
+        source = CONTRACT_PATH.read_text(encoding="utf-8")
+        self.assertIn("self.SetOOCFn(self._run_ooc)", source)
+        self.assertIn("self.SetCombatFn(self._run_combat_phase)", source)
+        self.assertNotIn("self.SetSkillCastingFn(self._run_local_skill_logic)", source)
+
+
+class _SkillMethod:
+    def __init__(self, name, calls, outcomes):
+        self.name = name
+        self.calls = calls
+        self.outcomes = outcomes
+
+    def __call__(self, *args, **kwargs):
+        if False:
+            yield
+        self.calls.append(self.name)
+        values = self.outcomes.get(self.name, [False])
+        if len(values) > 1:
+            return values.pop(0)
+        return values[0]
+
+
+def _skill_group(names, calls, outcomes):
+    group = type("SkillGroup", (), {})()
+    for name in names:
+        setattr(group, name, _SkillMethod(name, calls, outcomes))
+    return group
+
+
+def _skillbook(calls, outcomes):
+    root = type("Skillbook", (), {})()
+    root.Paragon = type("Paragon", (), {})()
+    root.Paragon.Leadership = _skill_group(
+        ("Heroic_Refrain", "Aggressive_Refrain", "Anthem_of_Flame", "Theyre_on_Fire"),
+        calls,
+        outcomes,
+    )
+    root.Paragon.Motivation = _skill_group(
+        (
+            "Mending_Refrain",
+            "Energizing_Finale",
+            "Burning_Refrain",
+            "Blazing_Finale",
+            "Hasty_Refrain",
+        ),
+        calls,
+        outcomes,
+    )
+    root.Paragon.Command = _skill_group(("Bladeturn_Refrain", "Fall_Back"), calls, outcomes)
+    return root
+
+
+class ParagonRefrainReportedBarTests(unittest.TestCase):
+    def setUp(self):
+        _ChecksSkills.can_cast = True
+        self.calls = []
+        self.outcomes = {
+            "Heroic_Refrain": [True, True, True, False],
+            "Hasty_Refrain": [True, False],
+            "Aggressive_Refrain": [True, False],
+            "Theyre_on_Fire": [True, False],
+        }
+        self.build = object.__new__(ParagonRefrain)
+        self.build.skillbook = _skillbook(self.calls, self.outcomes)
+        self.build.IsInAggro = lambda: True
+        self.equipped = {
+            SKILL_IDS["Heroic_Refrain"],
+            SKILL_IDS["Hasty_Refrain"],
+            SKILL_IDS["Aggressive_Refrain"],
+            SKILL_IDS["Theyre_on_Fire"],
+        }
+        self.build.IsSkillEquipped = lambda skill_id: skill_id in self.equipped
+
+        def combat():
+            if False:
+                yield
+            self.calls.append("combat")
+            return True
+
+        self.build._run_combat = combat
+
+    def test_fresh_ticks_preserve_bootstrap_distribution_and_maintenance_order(self):
+        final_calls = []
+        for handler in (
+            self.build._run_ooc,
+            self.build._run_ooc,
+            self.build._run_combat_phase,
+            self.build._run_combat_phase,
+            self.build._run_combat_phase,
+            self.build._run_combat_phase,
+        ):
+            self.assertTrue(_run(handler()))
+            final_calls.append(self.calls[-1])
+
+        self.assertEqual(
+            final_calls,
+            [
+                "Heroic_Refrain",
+                "Heroic_Refrain",
+                "Heroic_Refrain",
+                "Hasty_Refrain",
+                "Aggressive_Refrain",
+                "Theyre_on_Fire",
+            ],
+        )
+        self.assertNotIn("combat", final_calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Py4GWCoreLib/Builds/Paragon/P_W/Defensive Refrain.py
+++ b/Py4GWCoreLib/Builds/Paragon/P_W/Defensive Refrain.py
@@ -123,7 +123,8 @@ class Paragon_Refrain(BuildMgr):
             return
 
         self.SetFallback("HeroAI", HeroAI_Build(standalone_fallback=True))
-        self.SetSkillCastingFn(self._run_local_skill_logic)
+        self.SetOOCFn(self._run_ooc)
+        self.SetCombatFn(self._run_combat_phase)
         # Named skillbook, not skills: BuildMgr.skills is the list[int] of
         # equipped skill ids that ValidateSkills sorts, and shadowing it with
         # the helper namespace makes that call raise TypeError.
@@ -138,20 +139,21 @@ class Paragon_Refrain(BuildMgr):
         Everything here has to be reachable while travelling: the refrains are
         maintained continuously, not re-established at every pull.
         """
-        # First, and deliberately so. Aggressive Refrain is a single cast that
-        # the bar's shouts then renew forever, so the sooner it lands the sooner
-        # we stop thinking about it - after that its HasEffect guard returns
-        # False instantly and it costs nothing to keep asking. It used to sit
-        # below the in-aggro guard AND below Heroic Refrain, which is why it was
-        # effectively never cast: by the time we were in combat, Heroic Refrain
-        # was spreading across the party one ally per tick and never yielded the
-        # tick to it.
-        if self.IsSkillEquipped(Aggressive_Refrain_ID) and (yield from self.skillbook.Paragon.Leadership.Aggressive_Refrain()):
+        # The elite, and the reason for the bar, must be first. Its helper casts
+        # on self until the Leadership bootstrap reaches 20, then walks the
+        # party. Refrains cast before that bootstrap would use the lower rank.
+        if self.IsSkillEquipped(Heroic_Refrain_ID) and (yield from self.skillbook.Paragon.Leadership.Heroic_Refrain()):
             return True
 
-        # The elite, and the reason for the bar. Self-stacks first, then walks
-        # the party; the helper's own logic decides which.
-        if self.IsSkillEquipped(Heroic_Refrain_ID) and (yield from self.skillbook.Paragon.Leadership.Heroic_Refrain()):
+        # Spread every equipped party refrain immediately after Heroic Refrain,
+        # in or out of combat. Entering combat must not postpone an incomplete
+        # distribution behind the rest of the combat rotation.
+        if (yield from self._run_refrain_spreading()):
+            return True
+
+        # Aggressive Refrain is self-only and is maintained by the same expiring
+        # shouts as the party refrains.
+        if self.IsSkillEquipped(Aggressive_Refrain_ID) and (yield from self.skillbook.Paragon.Leadership.Aggressive_Refrain()):
             return True
 
         if self.IsSkillEquipped(Anthem_of_Flame_ID) and (yield from self.skillbook.Paragon.Leadership.Anthem_of_Flame()):
@@ -163,14 +165,8 @@ class Paragon_Refrain(BuildMgr):
         if self.IsSkillEquipped(Theyre_on_Fire_ID) and (yield from self.skillbook.Paragon.Leadership.Theyre_on_Fire()):
             return True
 
-        # The secondary echoes are worth a tick while travelling, but not ahead
-        # of the defensive shouts once the fight starts - in combat they are
-        # retried at the tail of the rotation instead.
         if self.IsInAggro():
             return False
-
-        if (yield from self._run_refrain_spreading()):
-            return True
 
         # Travel speed. Ends on the holder's next attack, so the helper keeps it
         # to genuine out-of-combat movement.
@@ -349,9 +345,16 @@ class Paragon_Refrain(BuildMgr):
 
         return False
 
-    def _run_local_skill_logic(self):
+    def _run_ooc(self):
+        """Evaluate travelling upkeep from current state on every fresh tick."""
         if not Routines.Checks.Skills.CanCast():
-            yield from Routines.Yield.wait(100)
+            return False
+
+        return (yield from self._run_upkeep())
+
+    def _run_combat_phase(self):
+        """Evaluate upkeep before combat work without a cross-phase continuation."""
+        if not Routines.Checks.Skills.CanCast():
             return False
 
         if (yield from self._run_upkeep()):


### PR DESCRIPTION
## Summary
- register the Heroic Refrain contract with explicit out-of-combat and combat handlers
- evaluate upkeep from current game state at the start of every fresh phase tick
- prioritize Heroic Refrain bootstrap and party distribution before secondary refrains
- continue Mending/Hasty and other refrain distribution during combat instead of postponing it
- apply Aggressive Refrain after party refrain distribution, then maintain with Anthem of Flame or They're on Fire
- avoid pausing before upkeep when casting is temporarily unavailable

## Why
The contract previously used one generic skill-casting generator. Movement and out-of-combat/combat transitions could abandon that continuation after the initial Heroic Refrain cast. Current upstream also ordered Aggressive Refrain first and deferred secondary refrain spreading during combat, unlike the validated rotation.

## Verification
- 6 focused regression tests pass
- exact reported-bar progression covers Heroic Refrain bootstrap/distribution, Hasty Refrain, Aggressive Refrain, and They're on Fire across an OOC-to-combat transition
- installed equivalent behavior was validated in-game with Simple Vanquish
- read-only syntax parse and git diff --check pass

## Test environment note
Full unittest discovery outside the game imports an existing native UI test package that requires the injected Py4GW module; that unrelated package cannot load in standalone Python.