### PR TITLE
Fix/heroai toggles and loot

### DIFF
--- a/Py4GWCoreLib/GlobalCache/shared_memory_src/AllAccounts.py
+++ b/Py4GWCoreLib/GlobalCache/shared_memory_src/AllAccounts.py
@@ -34,6 +34,10 @@ from .IntentStruct import IntentStruct
 #   from Py4GWCoreLib.GlobalCache.shared_memory_src import AllAccounts as _wb_mod
 #   _wb_mod.WHITEBOARD_DEBUG = True
 WHITEBOARD_DEBUG: bool = False
+
+#: How old a RUNNING message may be before SendMessage treats it as wedged (its coroutine died
+#: before cleanup) instead of mid-flight. Must exceed the longest legitimate command runtime.
+_MESSAGE_RUNNING_STALE_MS = 60_000
 _HERO_SUBMIT_RETRY_AFTER: dict[tuple[int, int], int] = {}
 _PET_SUBMIT_RETRY_AFTER: dict[tuple[int, int], int] = {}
 _SLOT_SUBMIT_RETRY_COOLDOWN_MS = 5000
@@ -943,6 +947,17 @@ class AllAccounts(Structure):
 
             if message.ReceiverEmail != receiver_email:
                 continue  # This slot is not for the intended receiver
+
+            if message.SenderEmail != sender_email:
+                continue  # This slot is from a different sender
+
+            if message.Running:
+                # A running message may be mid-flight (its coroutine is alive) or wedged (its
+                # coroutine died before cleanup). Reuse the slot only while it is fresh; a stale
+                # running message counts as dead so a new send can always get through.
+                if int(PySystem.get_tick_count64() - message.Timestamp) < _MESSAGE_RUNNING_STALE_MS:
+                    return i
+                continue
             
             if int(message.Command) != int(command.value):
                 continue  # This slot has a different command (could be from another sender)
@@ -957,7 +972,7 @@ class AllAccounts(Structure):
             if message_extra_data != normalized_extra_data:
                 continue  # This slot has different extra data (could be from another sender or an old message)
             
-            return i  # Matching active message is already queued/running; reuse it instead of duplicating it.
+            return i  # Matching pending message is already queued; reuse it instead of duplicating it.
         
         for i in range(SHMEM_MAX_PLAYERS):
             message = self.GetInbox(i)

--- a/Py4GWCoreLib/HeroAI/cache_data.py
+++ b/Py4GWCoreLib/HeroAI/cache_data.py
@@ -303,6 +303,11 @@ class CacheData:
                     self._shmem_options_valid = True
 
                 self._republish_options_if_slot_changed()
+
+                leader_options = GLOBAL_CACHE.ShMem.GetHeroAIOptionsByPartyNumber(0)
+                if leader_options is not None:
+                    self.global_options = detached_hero_ai_options(leader_options)
+
                 self.data.party_position = int(self.account_data.AgentPartyData.PartyPosition)
                 self.data.is_leader = bool(
                     getattr(self.account_data.AgentPartyData, "IsPartyLeader", False)

--- a/Py4GWCoreLib/HeroAI/ui.py
+++ b/Py4GWCoreLib/HeroAI/ui.py
@@ -81,6 +81,23 @@ template_code = ""
 configure_consumables_window_open: bool = False
 configure_base_consumables_window_open: bool = False
 
+
+def _live_hero_options(account_data: AccountStruct) -> HeroAIOptionStruct | None:
+    """Resolve the live shared-memory HeroAI options for an account.
+
+    Shared-memory structs are live views, so mutating them publishes the change
+    to every client. The party-cache options are detached copies (see
+    party_cache.detached_hero_ai_options) and must not be used as a write target.
+    Hero slots share their owner's email, so they resolve by party number first.
+    """
+    if account_data.IsHero:
+        return GLOBAL_CACHE.ShMem.GetHeroAIOptionsByPartyNumber(int(account_data.AgentPartyData.PartyPosition))
+    live = GLOBAL_CACHE.ShMem.GetHeroAIOptionsFromEmail(account_data.AccountEmail)
+    if live is not None:
+        return live
+    return GLOBAL_CACHE.ShMem.GetHeroAIOptionsByPartyNumber(int(account_data.AgentPartyData.PartyPosition))
+
+
 widget_handler = get_widget_handler()
 module_info = None
 
@@ -698,6 +715,9 @@ def draw_skill_bar(height: float, account_data: AccountStruct, hero_options: Opt
             if io.key_shift:
                 if hero_options:
                     hero_options.Skills[slot] = not hero_options.Skills[slot]
+                    live_options = _live_hero_options(account_data)
+                    if live_options is not None:
+                        live_options.Skills[slot] = hero_options.Skills[slot]
 
             else:
                 target_id = get_skill_target(account_data, skill)
@@ -1238,16 +1258,22 @@ def draw_buttons(account_data: AccountStruct, cached_data: CacheData, message_qu
             return -1
         
         def clear_hero_flag():
+            live_options = _live_hero_options(account_data)
+            if live_options is not None:
+                live_options.IsFlagged = False
+                live_options.FlagPos.x = 0.0
+                live_options.FlagPos.y = 0.0
+                live_options.AllFlag.x = 0.0
+                live_options.AllFlag.y = 0.0
+                live_options.FlagFacingAngle = 0.0
             options = cached_data.party.options.get(account_data.AgentData.AgentID)
-            if not options:
-                return -1
-            
-            options.IsFlagged = False
-            options.FlagPos.x = 0.0
-            options.FlagPos.y = 0.0
-            options.AllFlag.x = 0.0
-            options.AllFlag.y = 0.0
-            options.FlagFacingAngle = 0.0
+            if options:
+                options.IsFlagged = False
+                options.FlagPos.x = 0.0
+                options.FlagPos.y = 0.0
+                options.AllFlag.x = 0.0
+                options.AllFlag.y = 0.0
+                options.FlagFacingAngle = 0.0
             party_pos = int(account_data.AgentPartyData.PartyPosition)
             if 0 < party_pos <= GLOBAL_CACHE.Party.GetHeroCount():
                 GLOBAL_CACHE.Party.Heroes.UnflagHero(party_pos)
@@ -1520,6 +1546,9 @@ def draw_hero_panel(window: WindowModule, account_data: AccountStruct, cached_da
                 
                 if active != value:
                     ConsoleLog("HeroAI", f"Set {name} to {active} for hero {account_data.AgentData.CharacterName} | Party Position {account_data.AgentPartyData.PartyPosition}")
+                    live_options = _live_hero_options(account_data)
+                    if live_options is not None and hasattr(live_options, name):
+                        setattr(live_options, name, active)
                     setattr(options, name, active)
                 
                 PyImGui.same_line(0, 2)

--- a/Py4GWCoreLib/HeroAI/ui_base.py
+++ b/Py4GWCoreLib/HeroAI/ui_base.py
@@ -30,6 +30,18 @@ _SKILL_NAME_SUFFIXES: dict[str, str] = {
 }
 _skill_name_suffix_cache: dict[int, str] | None = None
 
+#: Muted red tints for the control panel's state toggles when they are OFF, so the live
+#: HeroAI option state is visible at a glance (ON keeps the theme colors).
+_OFF_TOGGLE_TINT = (170, 55, 55, 255)
+_OFF_TOGGLE_TINT_HOVERED = (200, 70, 70, 255)
+_OFF_TOGGLE_TINT_ACTIVE = (230, 90, 90, 255)
+
+#: Amber tints for the top-level (toggle-all) row when an option is on for some accounts
+#: but off for others, so a mixed state is never mistaken for "off everywhere".
+_MIXED_TOGGLE_TINT = (190, 140, 40, 255)
+_MIXED_TOGGLE_TINT_HOVERED = (215, 160, 50, 255)
+_MIXED_TOGGLE_TINT_ACTIVE = (240, 185, 60, 255)
+
 
 def _get_skill_name_suffix(skill_id: int) -> str:
     global _skill_name_suffix_cache
@@ -347,6 +359,68 @@ class HeroAI_BaseUI:
     def DrawPanelButtons(identifier: str, source_game_option: HeroAIOptionStruct, set_global: bool = False):
         style = ImGui.get_style()
 
+        def group_option_counts() -> dict[str, tuple[int, int]]:
+            """(accounts with the option ON, total accounts) per option, across the party's player accounts."""
+            option_names = ("Following", "Avoidance", "Looting", "Targeting", "Combat")
+            counts: dict[str, tuple[int, int]] = {name: (0, 0) for name in option_names}
+            party_cache: CacheData = CacheData()
+            for account in party_cache.party.accounts.values():
+                if (
+                    not account
+                    or not account.IsSlotActive
+                    or account.IsHero
+                    or account.AgentPartyData.PartyID != GLOBAL_CACHE.Party.GetPartyID()
+                ):
+                    continue
+                account_options = GLOBAL_CACHE.ShMem.GetHeroAIOptionsFromEmail(account.AccountEmail)
+                if not account_options:
+                    continue
+                for name in option_names:
+                    on, total = counts[name]
+                    counts[name] = (on + (1 if bool(getattr(account_options, name)) else 0), total + 1)
+            return counts
+
+        def draw_state_toggle(icon: str, label: str, value: bool, width: float, height: float) -> bool:
+            """A toggle button tinted by its live state: OFF red, mixed amber, ON theme.
+
+            The top-level (toggle-all) row passes party-wide counts via ``group_counts``: all
+            off -> red, mixed -> amber, all on -> theme. Per-account rows only have their own
+            value: off -> red, on -> theme.
+            """
+            counts = group_counts.get(label) if group_counts else None
+            if counts and counts[1] > 0:
+                if counts[0] == 0:
+                    state, base = "all_off", "disabled"
+                elif counts[0] < counts[1]:
+                    state, base = "mixed", "enabled" if value else "disabled"
+                else:
+                    state, base = "all_on", "enabled"
+            else:
+                state, base = ("all_off", "disabled") if not value else ("all_on", "enabled")
+
+            tint = None
+            if state == "all_off":
+                tint = (_OFF_TOGGLE_TINT, _OFF_TOGGLE_TINT_HOVERED, _OFF_TOGGLE_TINT_ACTIVE)
+            elif state == "mixed":
+                tint = (_MIXED_TOGGLE_TINT, _MIXED_TOGGLE_TINT_HOVERED, _MIXED_TOGGLE_TINT_ACTIVE)
+
+            trio = (
+                (style.ToggleButtonEnabled, style.ToggleButtonEnabledHovered, style.ToggleButtonEnabledActive)
+                if base == "enabled"
+                else (style.ToggleButtonDisabled, style.ToggleButtonDisabledHovered, style.ToggleButtonDisabledActive)
+            )
+            if tint:
+                for color, rgba in zip(trio, tint):
+                    color.push_color(rgba)
+            clicked = ImGui.toggle_button(icon + "##" + label + identifier, value, width, height)
+            if tint:
+                for color, _rgba in zip(trio, tint):
+                    color.pop_color()
+            ImGui.show_tooltip(
+                "%s - %d/%d accounts on" % (label, counts[0], counts[1]) if counts and counts[1] > 0 else label
+            )
+            return clicked
+
         def set_global_option(game_option: HeroAIOptionStruct, option_name: str = "", skill_index: int = -1):
             cached_data: CacheData = CacheData()
             accounts = cached_data.party.accounts.values()
@@ -381,48 +455,55 @@ class HeroAI_BaseUI:
         style.ItemSpacing.push_style_var(0, 0)
         style.CellPadding.push_style_var(2, 2)
 
+        group_counts = group_option_counts() if set_global else None
+
         if PyImGui.begin_table(f"GameOptionTable##{identifier}", 5, 0, table_width, btn_size + 2):
             PyImGui.table_next_row()
             PyImGui.table_next_column()
-            following = ImGui.toggle_button(IconsFontAwesome5.ICON_RUNNING + "##Following" + identifier, source_game_option.Following, btn_size, btn_size)
+            following = draw_state_toggle(
+                IconsFontAwesome5.ICON_RUNNING, "Following", source_game_option.Following, btn_size, btn_size
+            )
             if following != source_game_option.Following:
                 source_game_option.Following = following
                 if set_global:
                     set_global_option(source_game_option, "Following")
-            ImGui.show_tooltip("Following")
 
             PyImGui.table_next_column()
-            avoidance = ImGui.toggle_button(IconsFontAwesome5.ICON_PODCAST + "##Avoidance" + identifier, source_game_option.Avoidance, btn_size, btn_size)
+            avoidance = draw_state_toggle(
+                IconsFontAwesome5.ICON_PODCAST, "Avoidance", source_game_option.Avoidance, btn_size, btn_size
+            )
             if avoidance != source_game_option.Avoidance:
                 source_game_option.Avoidance = avoidance
                 if set_global:
                     set_global_option(source_game_option, "Avoidance")
-            ImGui.show_tooltip("Avoidance")
 
             PyImGui.table_next_column()
-            looting = ImGui.toggle_button(IconsFontAwesome5.ICON_COINS + "##Looting" + identifier, source_game_option.Looting, btn_size, btn_size)
+            looting = draw_state_toggle(
+                IconsFontAwesome5.ICON_COINS, "Looting", source_game_option.Looting, btn_size, btn_size
+            )
             if looting != source_game_option.Looting:
                 source_game_option.Looting = looting
                 if set_global:
                     set_global_option(source_game_option, "Looting")
-            ImGui.show_tooltip("Looting")
 
             PyImGui.table_next_column()
-            targeting = ImGui.toggle_button(IconsFontAwesome5.ICON_BULLSEYE + "##Targeting" + identifier, source_game_option.Targeting, btn_size, btn_size)
+            targeting = draw_state_toggle(
+                IconsFontAwesome5.ICON_BULLSEYE, "Targeting", source_game_option.Targeting, btn_size, btn_size
+            )
             if targeting != source_game_option.Targeting:
                 source_game_option.Targeting = targeting
                 if set_global:
                     ConsoleLog("HeroAI", f"Setting Targeting to {targeting} for all heroes in party.")
                     set_global_option(source_game_option, "Targeting")
-            ImGui.show_tooltip("Targeting")
 
             PyImGui.table_next_column()
-            combat = ImGui.toggle_button(IconsFontAwesome5.ICON_SKULL_CROSSBONES + "##Combat" + identifier, source_game_option.Combat, btn_size, btn_size)
+            combat = draw_state_toggle(
+                IconsFontAwesome5.ICON_SKULL_CROSSBONES, "Combat", source_game_option.Combat, btn_size, btn_size
+            )
             if combat != source_game_option.Combat:
                 source_game_option.Combat = combat
                 if set_global:
                     set_global_option(source_game_option, "Combat")
-            ImGui.show_tooltip("Combat")
             PyImGui.end_table()
 
         style.ButtonPadding.push_style_var(5 if style.Theme not in ImGui.Textured_Themes else 0, 3 if style.Theme not in ImGui.Textured_Themes else 2)

--- a/Py4GWCoreLib/HeroAI/ui_base.py
+++ b/Py4GWCoreLib/HeroAI/ui_base.py
@@ -2329,7 +2329,9 @@ class HeroAI_BaseUI:
                 for account in sorted_by_party_position:
                     if account and account.IsSlotActive and not account.IsHero and account.AgentPartyData.PartyID == GLOBAL_CACHE.Party.GetPartyID():
                         index += 1
-                        original_game_option = cached_data.party.options.get(account.AgentData.AgentID)
+                        original_game_option = GLOBAL_CACHE.ShMem.GetHeroAIOptionsFromEmail(account.AccountEmail)
+                        if original_game_option is None:
+                            original_game_option = cached_data.party.options.get(account.AgentData.AgentID)
                         if PyImGui.tree_node(f"{index}. {account.AgentData.CharacterName}##ControlPlayer{index}"):
                             if original_game_option is not None:
                                 HeroAI_BaseUI.DrawPanelButtons(account.AccountEmail, original_game_option)

--- a/Py4GWCoreLib/HeroAI/windows.py
+++ b/Py4GWCoreLib/HeroAI/windows.py
@@ -13,8 +13,18 @@ from .globals import capture_mouse_timer, show_area_rings, show_hero_follow_grid
 from .utils import IsHeroFlagged, DrawFlagAll, DrawHeroFlag, DistanceFromWaypoint, SameMapAsAccount
 from .settings import Settings
 
-from .ui import (draw_combined_hero_panel, draw_command_panel, draw_configure_window, draw_dialog_overlay,
-                       draw_hero_panel, draw_party_overlay, draw_party_search_overlay, draw_skip_cutscene_overlay)
+from .ui import (
+    draw_base_consumables_window,
+    draw_combined_hero_panel,
+    draw_command_panel,
+    draw_configure_window,
+    draw_consumables_window,
+    draw_dialog_overlay,
+    draw_hero_panel,
+    draw_party_overlay,
+    draw_party_search_overlay,
+    draw_skip_cutscene_overlay,
+)
 from .call_target import CallTarget
 
 from .cache_data import CacheData
@@ -231,6 +241,11 @@ class HeroAI_FloatingWindows():
             # Command Hotbars are deprecated — their commands now live on the Launch Bar (see
             # Py4GWCoreLib/HeroAI/command_api.py). The saved hotbar data is kept only so the "Import to Launch
             # Bar" button in the Hotbars settings tab can migrate it; it is no longer rendered.
+            # The consumables windows used to be hosted by the hotbar renderer; keep drawing them here
+            # so "Open Consumables" (launch bar / command catalog) and the base-UI candy-cane toggle work.
+
+            draw_consumables_window(cached_data)
+            draw_base_consumables_window(cached_data)
 
             draw_dialog_overlay(cached_data, HeroAI_FloatingWindows.messages)
     

--- a/Widgets/System/Messaging.py
+++ b/Widgets/System/Messaging.py
@@ -2122,19 +2122,20 @@ def PickUpLoot(index:int , message: SharedMessageStruct):
         SHMEM_ZERO_EPOCH = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0).timestamp()
         return int((time.time() - SHMEM_ZERO_EPOCH) * 1000)
 
-    GLOBAL_CACHE.ShMem.MarkMessageAsRunning(message.ReceiverEmail, index)
-    SnapshotHeroAIOptions(message.ReceiverEmail)
-
-    loot_array = LootFilters().GetLootArray(Range.Earshot.value)
-    if len(loot_array) == 0:
-        RestoreHeroAISnapshot(message.ReceiverEmail)
-        GLOBAL_CACHE.ShMem.MarkMessageAsFinished(message.ReceiverEmail, index)
-        return
-
-    ConsoleLog(MODULE_NAME, "Starting PickUpLoot routine", Console.MessageType.Info, False)
-
     claimed_item_id = 0
     try:
+        # Everything from the running-mark down lives inside the try so the finally below always
+        # restores HeroAI options and finishes the message -- even when a step raises, a wedged
+        # (never-finished) message can no longer be left behind to swallow future PickUpLoot sends.
+        GLOBAL_CACHE.ShMem.MarkMessageAsRunning(message.ReceiverEmail, index)
+        SnapshotHeroAIOptions(message.ReceiverEmail)
+
+        loot_array = LootFilters().GetLootArray(Range.Earshot.value)
+        if len(loot_array) == 0:
+            return
+
+        ConsoleLog(MODULE_NAME, "Starting PickUpLoot routine", Console.MessageType.Info, False)
+
         DisableHeroAIOptions(message.ReceiverEmail)
         yield from Routines.Yield.wait(100)
         while True:


### PR DESCRIPTION
## Summary

Three independent fixes for the HeroAI control panel and the loot pickup pipeline:

1. **Hero panel toggles now actually apply** — the Following/Avoidance/Looting/Targeting/Combat toggles, Shift+click skill toggles and the clear-flag button were writing to detached party-cache copies, so the values never reached shared memory and the automation kept running with stale state (e.g. disabling "attack" on the main account did nothing).
2. **Loot pickup can no longer wedge permanently** — a stuck `PickUpLoot` message in shared memory could swallow every later pickup request silently.
3. **Control panel toggles show their live state** — red = off, and the top-level "toggle all" row now reflects the whole party (amber = mixed) instead of only the leader.

## Changes

### 1. HeroAI: publish panel toggles and flags to shared memory, restore consumables windows
`Py4GWCoreLib/HeroAI/ui.py`, `ui_base.py`, `cache_data.py`, `windows.py`

- Hero panel toggles write through to the **live shared-memory options** (resolved by party number for heroes, by email otherwise) instead of the detached party-cache copy, so combat/loot reads (`cached_data.account_options`) see the change.
- Shift+click skill enable/disable and the clear-hero-flag button do the same.
- The players-tree panel buttons resolve the live options view.
- `cache_data` refreshes `global_options` from the leader's live options each update (was a TODO).
- Consumables windows are drawn again — they were orphaned when the hotbar renderer was deprecated.

### 2. Fix loot pickup wedge: sender-aware SendMessage dedup, always-finish PickUpLoot
`Py4GWCoreLib/GlobalCache/shared_memory_src/AllAccounts.py`, `Widgets/System/Messaging.py`

- `SendMessage`'s dedup scan matched on receiver/command/params/extra-data **without the sender or the running state**, so one `PickUpLoot` message left stuck in "Running" (possible if the coroutine died in its pre-`finally` section) made every later button press collapse onto the dead slot — no new message, no pickup, no error. Dedup now requires the **same sender** and treats **stale running messages (older than 60 s)** as dead.
- `PickUpLoot` moves the running-mark, snapshot and loot scan inside the `try` whose `finally` always restores HeroAI options and finishes the message — a wedged (never-finished) message is structurally impossible from this path.

### 3. HeroAI: show live option state on the control panel toggles
`Py4GWCoreLib/HeroAI/ui_base.py`

- Control panel icon toggles are tinted by live state: **OFF red**, ON keeps the theme.
- The top-level (toggle-all) row shows the **party-wide** state instead of just the leader's: all off → red, mixed → amber, all on → theme.
- Top-level tooltips show the per-option account count (e.g. "Combat - 6/7 accounts on").
- Display-only; click behaviour unchanged.

## Verification

- `py_compile` passes on all changed files.
- Pyright: only pre-existing errors remain; none on changed lines.
- Black (120, skip-string-normalization): clean on all changed hunks.
- Offline loot engine tests (`test_loot_filter_matcher.py`, `test_filter_set_selection.py`) pass.
- Live-validated: loot pickup works after the fix (requires a game restart to clear any already-wedged message), and panel toggles/colours track the live shared-memory state.

## Notes

- The 60 s stale-message threshold exceeds the longest legitimate command runtime, so in-flight commands are never double-run.
- One restart is required after deploying to clear any message already wedged before the fix.