### PR TITLE
Classify Ray of Judgment bars as smite monk builds

### DIFF
--- a/Py4GWCoreLib/Builds/Monk/Mo_Any/Ray of Judgment.py
+++ b/Py4GWCoreLib/Builds/Monk/Mo_Any/Ray of Judgment.py
@@ -33,11 +33,11 @@ class Ray_of_Judgment(BuildMgr):
             template_code="OwAS4YIT+MuEWfAAAAAAAAwl",
             required_skills=[
                 Ray_of_Judgment_ID,
+            ],
+            optional_skills=[
                 Smite_Hex_ID,
                 Air_of_Superiority_ID,
                 Castigation_Signet_ID,
-            ],
-            optional_skills=[
                 Arcane_Echo_ID,
                 You_Move_Like_a_Dwarf_ID,
                 Smite_Condition_ID,


### PR DESCRIPTION
## Problem

The Ray of Judgment build contract required four exact skills: Ray of Judgment, Smite Hex, Air of Superiority, and Castigation Signet. A Monk using Ray of Judgment with a different smiting variant, including EVAS, therefore failed classification and fell back to generic HeroAI behavior.

Ray of Judgment itself identifies the offensive Smite Monk build. The other smiting and PvE skills are supported bar variants, not classification requirements.

## Change

- Require Monk primary plus Ray of Judgment.
- Treat Smite Hex, Air of Superiority, and Castigation Signet as optional supported skills.
- Leave the existing Smite Monk rotation, EVAS targeting, and generic HeroAI unchanged.

This allows Ray of Judgment bars to reach the dedicated smite rotation, where Ebon Vanguard Assassin Support is already handled.

## Scope and validation

- One build-definition file changed.
- Python compilation passed.
- Git diff integrity check passed.
- In-game validation remains separate and is pending.