### PR TITLE
Make Skills Unlocker discoverable and repair its UI scope

### DIFF
--- a/Examples and tests/tests/test_skills_unlocker_widget.py
+++ b/Examples and tests/tests/test_skills_unlocker_widget.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).parents[2]
+WIDGET_DIR = ROOT / "Widgets" / "Automation" / "Bots" / "SkillsUnlocker"
+WIDGET_PATH = WIDGET_DIR / "EOTN_SKILL_UNLOCKER.py"
+
+
+class SkillsUnlockerWidgetTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = WIDGET_PATH.read_text(encoding="utf-8")
+        start = cls.source.index("def draw_window_light")
+        end = cls.source.index("\n# Monkeypatch UI method", start)
+        cls.draw_window_source = cls.source[start:end]
+
+    def test_widget_folder_has_discovery_marker(self) -> None:
+        self.assertTrue(
+            (WIDGET_DIR / ".widget").is_file(),
+            "Skills Unlocker requires a .widget marker for widget discovery",
+        )
+
+    def test_draw_window_light_does_not_close_unopened_child_or_tab(self) -> None:
+        self.assertNotIn(
+            "PyImGui.end_child()",
+            self.draw_window_source,
+            "draw_window_light must not close a child scope it did not open",
+        )
+        self.assertNotIn(
+            "PyImGui.end_tab_item()",
+            self.draw_window_source,
+            "draw_window_light must not close child or tab scopes it did not open",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Widgets/Automation/Bots/SkillsUnlocker/.widget
+++ b/Widgets/Automation/Bots/SkillsUnlocker/.widget
@@ -1,0 +1,1 @@
+# Widget discovery marker.

--- a/Widgets/Automation/Bots/SkillsUnlocker/EOTN_SKILL_UNLOCKER.py
+++ b/Widgets/Automation/Bots/SkillsUnlocker/EOTN_SKILL_UNLOCKER.py
@@ -112,7 +112,10 @@ def draw_window_light(
 
 
     if not self._config.ini_key_initialized:
-        self._config.ini_key = Settings(f"{f"BottingClass/bot_{self._config.bot_name}"}/{f"bot_{self._config.bot_name}.ini"}", "account").name
+        self._config.ini_key = Settings(
+            f"BottingClass/bot_{self._config.bot_name}/bot_{self._config.bot_name}.ini",
+            "account",
+        ).name
         self._config.ini_key_initialized = True
 
     if not self._config.ini_key:
@@ -124,13 +127,9 @@ def draw_window_light(
         p_open=True,
         flags=PyImGui.WindowFlags.AlwaysAutoResize,
     ):
-                self._draw_main_child(main_child_dimensions, icon_path, iconwidth)
-                if additional_ui:
-                        additional_ui()
-                PyImGui.end_child()
-                PyImGui.end_tab_item()
-
-            
+        self._draw_main_child(main_child_dimensions, icon_path, iconwidth)
+        if additional_ui:
+            additional_ui()
 
     ImGui.End(self._config.ini_key)
 


### PR DESCRIPTION
## Summary
- add the missing `.widget` marker so Skills Unlocker appears in widget discovery
- repair `draw_window_light()` so it only closes the window scope it opens
- simplify the widget Settings key expression so the file passes the project Pyright check
- add focused regression coverage for discovery and ImGui scope ownership

## Scope
This PR intentionally contains no skill routes, NPC/dialogue handling, HeroAI changes, generic Botting changes, or custom diagnostics. YMLAD and IAU route work will be handled separately.

## Validation
- `python -m unittest "Examples and tests.tests.test_skills_unlocker_widget"` (2 tests passed)
- Python 3.11 and bundled Python 3.12 compilation passed for both changed Python files
- Pyright passed with 0 errors, 0 warnings, and 0 information messages
- `git diff --check` passed
- live widget discovery and injected ImGui behavior still require in-game validation