### PR TITLE
Target Ancestors' Rage by adjacent enemy density

### DIFF
--- a/Py4GWCoreLib/Agent.py
+++ b/Py4GWCoreLib/Agent.py
@@ -37,6 +37,11 @@ class Agent:
         """
         return Agent.GetAgentByID(agent_id) is not None
 
+    @staticmethod
+    def IsTargettable(agent_id: int) -> bool:
+        """Return whether Guild Wars permits selecting this agent as a target."""
+        return bool(PyAgent.get_agent_is_targettable(agent_id))
+
     _agent_cache: dict[int, "AgentStruct"] = {}
     _living_cache: dict[int, "AgentLivingStruct"] = {}
     _item_cache: dict[int, "AgentItemStruct"] = {}

--- a/Py4GWCoreLib/BuildMgr.py
+++ b/Py4GWCoreLib/BuildMgr.py
@@ -419,6 +419,7 @@ class BuildMgr:
             TargetLowestAllyMartial,
             TargetLowestAllyMelee,
             TargetLowestAllyRanged,
+            TargetAllyWithMostAdjacentEnemies,
             TargetAllyNonEnchanted,
             TargetAllyNonWeaponSpelled,
             TargetMinionNonEnchanted,
@@ -455,6 +456,8 @@ class BuildMgr:
             return TargetAllyNonEnchanted(**range_kwargs)
         if target_allegiance == Skilltarget.NonWeaponSpelledAlly.value:
             return Player.GetAgentID() if TargetAllyNonWeaponSpelled(**range_kwargs) else 0
+        if target_allegiance == Skilltarget.AllyWithAdjacentEnemies.value:
+            return TargetAllyWithMostAdjacentEnemies(distance=ally_distance)
 
         if target_allegiance in (
             Skilltarget.Ally.value,

--- a/Py4GWCoreLib/HeroAI/combat.py
+++ b/Py4GWCoreLib/HeroAI/combat.py
@@ -10,7 +10,7 @@ from Py4GWCoreLib.enums import SPIRIT_BUFF_MAP, ModelID
 from Py4GWCoreLib.GlobalCache.HexRemovalPriority import get_hexed_ally_for_removal
 from Py4GWCoreLib.EnemyBlacklist import EnemyBlacklist
 from .custom_skill import CustomSkillClass
-from .targeting import TargetLowestAlly, TargetLowestAllyEnergy, TargetClusteredEnemy, TargetLowestAllyCaster, TargetLowestAllyMartial, TargetLowestAllyMelee, TargetLowestAllyRanged, GetAllAlliesArray, TargetAllyWeaponSpell, TargetMinionOrAllyNonEnchanted, TargetMinionNonEnchanted, TargetAllyNonEnchanted, TargetAllyNonWeaponSpelled, TargetDeadPartyMember, IsResurrectablePartyMember
+from .targeting import TargetLowestAlly, TargetLowestAllyEnergy, TargetClusteredEnemy, TargetLowestAllyCaster, TargetLowestAllyMartial, TargetLowestAllyMelee, TargetLowestAllyRanged, TargetAllyWithMostAdjacentEnemies, GetAllAlliesArray, TargetAllyWeaponSpell, TargetMinionOrAllyNonEnchanted, TargetMinionNonEnchanted, TargetAllyNonEnchanted, TargetAllyNonWeaponSpelled, TargetDeadPartyMember, IsResurrectablePartyMember
 from .targeting import GetEnemyAttacking, GetEnemyCasting, GetEnemyCastingSpell, GetEnemyCastingSpellOrChant, GetEnemyInjured, GetEnemyConditioned, GetEnemyHealthy
 from .targeting import GetEnemyHexed, GetEnemyDegenHexed, GetEnemyEnchanted, GetEnemyMoving, GetEnemyKnockedDown
 from .targeting import GetEnemyBleeding, GetEnemyPoisoned, GetEnemyCrippled
@@ -899,6 +899,8 @@ class CombatClass:
             v_target = TargetLowestAllyRanged(filter_skill_id=self.skills[slot].skill_id)
             if v_target == 0 and not targeting_strict:
                 v_target = get_lowest_ally()
+        elif target_allegiance == Skilltarget.AllyWithAdjacentEnemies:
+            v_target = TargetAllyWithMostAdjacentEnemies()
         elif target_allegiance == Skilltarget.OtherAlly:
             if self.skills[slot].custom_skill_data.Nature == SkillNature.EnergyBuff.value:
                 v_target = TargetLowestAllyEnergy(other_ally=True, filter_skill_id=self.skills[slot].skill_id, less_energy=self.skills[slot].custom_skill_data.Conditions.LessEnergy)

--- a/Py4GWCoreLib/HeroAI/custom_skill_src/ritualist.py
+++ b/Py4GWCoreLib/HeroAI/custom_skill_src/ritualist.py
@@ -218,8 +218,9 @@ class RitualistSkills:
         skill = CustomSkill()
         skill.SkillID = GLOBAL_CACHE.Skill.GetID("Ancestors_Rage")
         skill.SkillType = SkillType.Skill.value
-        skill.TargetAllegiance = Skilltarget.AllyMartial.value
+        skill.TargetAllegiance = Skilltarget.AllyWithAdjacentEnemies.value
         skill.Nature = SkillNature.Offensive.value
+        skill.Conditions.TargetingStrict = True
         skill_data[skill.SkillID] = skill
 
         skill = CustomSkill()

--- a/Py4GWCoreLib/HeroAI/targeting.py
+++ b/Py4GWCoreLib/HeroAI/targeting.py
@@ -109,6 +109,72 @@ def TargetLowestAlly(other_ally=False, filter_skill_id=0, distance=Range.Spellca
     return Utils.GetFirstFromArray(ally_array)
 
 
+def TargetAllyWithMostAdjacentEnemies(
+    distance=Range.Spellcast.value,
+    adjacent_range=Range.Adjacent.value,
+    min_enemies=2,
+):
+    """Select any living allied creature surrounded by enough living foes.
+
+    Unlike the ordinary ally selectors, this intentionally includes spirits
+    and minions and does not apply persistent-effect filtering. Ancestors'
+    Rage ends after one second, so an effect-presence filter would incorrectly
+    suppress valid summoned targets whose effects are not observable.
+    """
+    player_id = Player.GetAgentID()
+    player_xy = Player.GetXY()
+    candidate_ids = set(AgentArray.GetAllyArray() or [])
+    candidate_ids.update(AgentArray.GetSpiritPetArray() or [])
+    candidate_ids.update(AgentArray.GetMinionArray() or [])
+    candidate_ids.update(AgentArray.GetNPCMinipetArray() or [])
+    if player_id:
+        candidate_ids.add(player_id)
+
+    candidates = [
+        agent_id
+        for agent_id in candidate_ids
+        if agent_id
+        and Agent.IsValid(agent_id)
+        and Agent.IsTargettable(agent_id)
+        and Agent.IsAlive(agent_id)
+        and Utils.Distance(Agent.GetXY(agent_id), player_xy) <= distance
+    ]
+
+    enemy_ids = Routines.Agents.GetFilteredEnemyArray(
+        player_xy[0],
+        player_xy[1],
+        distance + adjacent_range,
+    )
+    enemy_ids = [
+        enemy_id
+        for enemy_id in enemy_ids or []
+        if Agent.IsValid(enemy_id) and Agent.IsAlive(enemy_id)
+    ]
+
+    scored: list[tuple[int, float, int]] = []
+    for agent_id in candidates:
+        target_xy = Agent.GetXY(agent_id)
+        enemy_count = sum(
+            1
+            for enemy_id in enemy_ids
+            if Utils.Distance(target_xy, Agent.GetXY(enemy_id)) <= adjacent_range
+        )
+        if enemy_count < min_enemies:
+            continue
+        scored.append(
+            (
+                -enemy_count,
+                Utils.Distance(target_xy, player_xy),
+                agent_id,
+            )
+        )
+
+    if not scored:
+        return 0
+    scored.sort()
+    return scored[0][2]
+
+
 def TargetMinionOrAllyNonEnchanted(filter_skill_id=0, distance=Range.Spellcast.value):
     minion_array = AgentArray.GetMinionArray()
     minion_array = AgentArray.Filter.ByDistance(minion_array, Player.GetXY(), distance)

--- a/Py4GWCoreLib/HeroAI/types.py
+++ b/Py4GWCoreLib/HeroAI/types.py
@@ -143,6 +143,7 @@ class Skilltarget (IntEnum):
     ResurrectionAlly = 40
     HexedAlly = 41
     EnemyNotNearby = 42
+    AllyWithAdjacentEnemies = 43
 
 
 

--- a/Py4GWCoreLib/SkillManager.py
+++ b/Py4GWCoreLib/SkillManager.py
@@ -1,7 +1,7 @@
 from Py4GWCoreLib.HeroAI.custom_skill import CustomSkillClass
 from Py4GWCoreLib.HeroAI.types import SkillType,SkillNature, Skilltarget
 
-from Py4GWCoreLib.HeroAI.targeting import TargetLowestAlly, TargetLowestAllyEnergy, TargetClusteredEnemy, TargetLowestAllyCaster, TargetLowestAllyMartial, TargetLowestAllyMelee, TargetLowestAllyRanged, GetAllAlliesArray
+from Py4GWCoreLib.HeroAI.targeting import TargetLowestAlly, TargetLowestAllyEnergy, TargetClusteredEnemy, TargetLowestAllyCaster, TargetLowestAllyMartial, TargetLowestAllyMelee, TargetLowestAllyRanged, TargetAllyWithMostAdjacentEnemies, GetAllAlliesArray
 from Py4GWCoreLib.HeroAI.targeting import TargetMinionOrAllyNonEnchanted, TargetMinionNonEnchanted, TargetAllyNonEnchanted, TargetAllyNonWeaponSpelled
 from Py4GWCoreLib.HeroAI.targeting import GetEnemyAttacking, GetEnemyCasting, GetEnemyCastingSpell, GetEnemyInjured, GetEnemyConditioned, GetEnemyHealthy
 from Py4GWCoreLib.HeroAI.targeting import GetEnemyHexed, GetEnemyDegenHexed, GetEnemyEnchanted, GetEnemyMoving, GetEnemyKnockedDown
@@ -457,6 +457,8 @@ def _GetAppropiateTarget(
             v_target = _TargetLowestAllyRanged(filter_skill_id=skills[slot].skill_id)
             if v_target == 0 and not targeting_strict:
                 v_target = lowest_ally
+        elif target_allegiance == Skilltarget.AllyWithAdjacentEnemies:
+            v_target = TargetAllyWithMostAdjacentEnemies()
         elif target_allegiance == Skilltarget.OtherAlly:
             if skills[slot].custom_skill_data.Nature == SkillNature.EnergyBuff.value:
                 v_target = _TargetLowestAllyEnergy(other_ally=True, filter_skill_id=skills[slot].skill_id)
@@ -1563,6 +1565,8 @@ class SkillManager:
                 v_target = Routines.Targeting.TargetLowestAllyRanged(filter_skill_id=self.skills[slot].skill_id)
                 if v_target == 0 and not targeting_strict:
                     v_target = get_lowest_ally()
+            elif target_allegiance == Skilltarget.AllyWithAdjacentEnemies:
+                v_target = TargetAllyWithMostAdjacentEnemies()
             elif target_allegiance == Skilltarget.OtherAlly:
                 if self.skills[slot].custom_skill_data.Nature == SkillNature.EnergyBuff.value:
                     v_target = Routines.Targeting.TargetLowestAllyEnergy(other_ally=True, filter_skill_id=self.skills[slot].skill_id)


### PR DESCRIPTION
Adds a dedicated strict ally target mode for Ancestors' Rage. It selects a living, targetable allied creature with at least two adjacent living foes, including party allies, the player, spirits and pets, minions, and friendly NPCs or summons. The mode is wired through regular HeroAI, BuildMgr/headless, and legacy SkillManager without changing AllyMartial behavior for other skills. Verification: all seven changed Python files compile; eight focused local targeting and wiring tests passed; Ancestors' Rage targeting was confirmed working in-game. Local test scripts are intentionally excluded from this PR.