### PR TITLE
Hero Helper: maintain Strength of Honor on bow users

### DIFF
--- a/Examples and tests/tests/herohelper_local/test_strength_of_honor.py
+++ b/Examples and tests/tests/herohelper_local/test_strength_of_honor.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+HERO_HELPER = ROOT / "Widgets" / "Automation" / "Enhancements" / "HeroHelper.py"
+
+
+def _function_node(name: str, *, class_name: str | None = None) -> ast.FunctionDef:
+    tree = ast.parse(HERO_HELPER.read_text(encoding="utf-8"))
+    body = tree.body
+    if class_name is not None:
+        owner = next(
+            node
+            for node in body
+            if isinstance(node, ast.ClassDef) and node.name == class_name
+        )
+        body = owner.body
+    return next(
+        node
+        for node in body
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+
+
+def _load_function(name: str, namespace: dict, *, class_name: str | None = None):
+    node = _function_node(name, class_name=class_name)
+    node.decorator_list = []
+    module = ast.Module(body=[node], type_ignores=[])
+    ast.fix_missing_locations(module)
+    exec(compile(module, HERO_HELPER, "exec"), namespace)
+    return namespace[name]
+
+
+class FakePlayer:
+    agent_id = 1
+
+    @classmethod
+    def GetAgentID(cls):
+        return cls.agent_id
+
+
+class FakeAgent:
+    weapon_item_type = 0
+    martial = False
+
+    @classmethod
+    def GetWeaponItemType(cls, _agent_id):
+        return cls.weapon_item_type
+
+    @classmethod
+    def IsMartial(cls, _agent_id):
+        return cls.martial
+
+
+holds_physical_weapon = _load_function(
+    "holds_physical_weapon",
+    {"Player": FakePlayer, "Agent": FakeAgent},
+    class_name="Helper",
+)
+
+
+class FakeParty:
+    hero_count = 1
+
+    @classmethod
+    def GetHeroCount(cls):
+        return cls.hero_count
+
+
+class FakeSkill:
+    @staticmethod
+    def GetID(name):
+        if name != "Strength_of_Honor":
+            raise AssertionError(name)
+        return 243
+
+
+class FakeHelper:
+    delay_ready = True
+    alive = True
+    smartcast_result = (2, 4, 243, 1)
+    smartcast_calls = []
+
+    @classmethod
+    def reset(cls):
+        cls.delay_ready = True
+        cls.alive = True
+        cls.smartcast_result = (2, 4, 243, 1)
+        cls.smartcast_calls = []
+
+    @classmethod
+    def can_execute_with_delay(cls, identifier, delay_ms):
+        return cls.delay_ready and identifier == "smart_honor" and delay_ms == 1000
+
+    @classmethod
+    def is_agent_alive(cls, _agent_id):
+        return cls.alive
+
+    @staticmethod
+    def holds_physical_weapon():
+        return holds_physical_weapon()
+
+    @staticmethod
+    def get_spell_cast_range():
+        return 1248.0
+
+    @classmethod
+    def smartcast_hero_skill(cls, **kwargs):
+        cls.smartcast_calls.append(kwargs)
+        return cls.smartcast_result
+
+
+executed_skills = []
+
+
+def fake_execute_hero_skill(*args):
+    executed_skills.append(args)
+
+
+smart_honor = _load_function(
+    "smart_honor",
+    {
+        "Party": FakeParty,
+        "Player": FakePlayer,
+        "Skill": FakeSkill,
+        "Helper": FakeHelper,
+        "execute_hero_skill": fake_execute_hero_skill,
+    },
+)
+
+
+class FakeTreeNodeFlags:
+    DefaultOpen = 1
+
+
+class FakePyImGui:
+    TreeNodeFlags = FakeTreeNodeFlags
+
+    @staticmethod
+    def text_disabled(_text):
+        pass
+
+    @staticmethod
+    def separator():
+        pass
+
+    @staticmethod
+    def collapsing_header(_label, _flags):
+        return True
+
+    @staticmethod
+    def same_line(*_args):
+        pass
+
+    @staticmethod
+    def spacing():
+        pass
+
+    @staticmethod
+    def is_item_hovered():
+        return False
+
+    @staticmethod
+    def set_tooltip(_text):
+        pass
+
+
+class FakeImGui:
+    @staticmethod
+    def DrawTexture(*_args):
+        pass
+
+
+class FakeUIHelper:
+    @staticmethod
+    def get_profession_icon_path(_profession):
+        return ""
+
+    @staticmethod
+    def get_skill_icon_path(_skill):
+        return ""
+
+    @staticmethod
+    def visible_checkbox(label, previous):
+        if label.startswith("Strength of Honor##"):
+            return True
+        return previous
+
+    @staticmethod
+    def log_event(**_kwargs):
+        pass
+
+
+class FakeConfig:
+    def __init__(self):
+        for attr in (
+            "smart_panic_enabled",
+            "smart_honor_enabled",
+            "smart_life_bond_enabled",
+            "smart_vigorous_enabled",
+            "smart_bip_enabled",
+            "smart_dark_aura_enabled",
+            "smart_incoming_fallback_enabled",
+            "smart_sos_enabled",
+            "smart_st_enabled",
+            "smart_splinter_enabled",
+            "smart_xinrae_enabled",
+        ):
+            setattr(self, attr, False)
+        self.save_calls = 0
+
+    def save(self):
+        self.save_calls += 1
+
+
+draw_tab_smart_skills = _load_function(
+    "draw_tab_smart_skills",
+    {
+        "Helper": FakeUIHelper,
+        "PyImGui": FakePyImGui,
+        "ImGui": FakeImGui,
+        "os": os,
+    },
+)
+
+
+class PhysicalWeaponTests(unittest.TestCase):
+    def setUp(self):
+        FakePlayer.agent_id = 1
+        FakeAgent.weapon_item_type = 0
+        FakeAgent.martial = False
+
+    def test_all_supported_physical_item_types_are_accepted(self):
+        for item_type in (2, 5, 15, 27, 32, 35, 36):
+            with self.subTest(item_type=item_type):
+                FakeAgent.weapon_item_type = item_type
+                self.assertTrue(holds_physical_weapon())
+
+    def test_bow_does_not_depend_on_high_level_weapon_name_mapping(self):
+        FakeAgent.weapon_item_type = 5
+        FakeAgent.martial = False
+        self.assertTrue(holds_physical_weapon())
+
+    def test_nonphysical_item_is_rejected(self):
+        FakeAgent.weapon_item_type = 22  # wand
+        self.assertFalse(holds_physical_weapon())
+
+    def test_high_level_martial_classification_remains_a_fallback(self):
+        FakeAgent.weapon_item_type = 255
+        FakeAgent.martial = True
+        self.assertTrue(holds_physical_weapon())
+
+    def test_missing_player_is_rejected(self):
+        FakePlayer.agent_id = 0
+        FakeAgent.weapon_item_type = 5
+        self.assertFalse(holds_physical_weapon())
+
+
+class StrengthOfHonorBehaviorTests(unittest.TestCase):
+    def setUp(self):
+        FakePlayer.agent_id = 1
+        FakeParty.hero_count = 1
+        FakeAgent.weapon_item_type = 0
+        FakeAgent.martial = False
+        FakeHelper.reset()
+        executed_skills.clear()
+
+    def test_bow_reaches_shared_smartcast_and_manual_hero_command(self):
+        FakeAgent.weapon_item_type = 5
+
+        smart_honor()
+
+        self.assertEqual(len(FakeHelper.smartcast_calls), 1)
+        call = FakeHelper.smartcast_calls[0]
+        self.assertEqual(call["skill_id"], 243)
+        self.assertTrue(call["allow_out_of_combat"])
+        self.assertTrue(call["effect_check"])
+        self.assertEqual(executed_skills, [FakeHelper.smartcast_result])
+
+    def test_wand_stops_before_shared_smartcast(self):
+        FakeAgent.weapon_item_type = 22
+
+        smart_honor()
+
+        self.assertEqual(FakeHelper.smartcast_calls, [])
+        self.assertEqual(executed_skills, [])
+
+    def test_existing_shared_smartcast_rejection_remains_authoritative(self):
+        FakeAgent.weapon_item_type = 5
+        FakeHelper.smartcast_result = None
+
+        smart_honor()
+
+        self.assertEqual(len(FakeHelper.smartcast_calls), 1)
+        self.assertEqual(executed_skills, [])
+
+    def test_dead_player_stops_before_weapon_and_smartcast(self):
+        FakeAgent.weapon_item_type = 5
+        FakeHelper.alive = False
+
+        smart_honor()
+
+        self.assertEqual(FakeHelper.smartcast_calls, [])
+        self.assertEqual(executed_skills, [])
+
+
+class SmartSkillPersistenceTests(unittest.TestCase):
+    def test_strength_of_honor_toggle_saves_immediately(self):
+        config = FakeConfig()
+
+        draw_tab_smart_skills(config)
+
+        self.assertTrue(config.smart_honor_enabled)
+        self.assertEqual(config.save_calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Widgets/Automation/Enhancements/HeroHelper.py
+++ b/Widgets/Automation/Enhancements/HeroHelper.py
@@ -810,6 +810,19 @@ class Helper:
         return item_type in {2, 15, 27, 32, 35, 36}  # axe, hammer, sword, daggers, scythe, spear
 
     @staticmethod
+    def holds_physical_weapon():
+        player_id = Player.GetAgentID()
+        if not player_id:
+            return False
+
+        # Query the active main-hand item directly.  The equipped-items bag is
+        # not ordered by weapon slot, and the higher-level weapon-name mapping
+        # can lag newly exposed weapon variants.
+        weapon_item_type = Agent.GetWeaponItemType(player_id)
+        physical_item_types = {2, 5, 15, 27, 32, 35, 36}
+        return weapon_item_type in physical_item_types or Agent.IsMartial(player_id)
+
+    @staticmethod
     def format_spell_title_case(spell_name):
         skip = {"of"}
         words = spell_name.split()
@@ -1071,7 +1084,7 @@ def smart_honor():
     player_id = Player.GetAgentID()
     if not Helper.is_agent_alive(player_id):
         return
-    if not Helper.is_melee_class() or not Helper.holds_melee_weapon():
+    if not Helper.holds_physical_weapon():
         return
 
     result = Helper.smartcast_hero_skill(
@@ -1447,7 +1460,7 @@ def draw_tab_smart_skills(config):
             ("Panic", "smart_panic_enabled", "Casts Panic on clustered enemy groups, preferring caster clumps.", "Panic"),
         ]),
         ("Monk", [
-            ("Strength of Honor", "smart_honor_enabled", "[DISABLE HERO CASTING] Maintains Honor on melee player.", "Strength_of_Honor"),
+            ("Strength of Honor", "smart_honor_enabled", "[DISABLE HERO CASTING] Maintains Honor on physical weapon user.", "Strength_of_Honor"),
             ("Life Bond", "smart_life_bond_enabled", "[DISABLE HERO CASTING] Maintains Life Bond on melee player.", "Life_Bond"),
             ("Vigorous Spirit", "smart_vigorous_enabled", "Casts Vigorous Spirit on melee player in combat.", "Vigorous_Spirit"),
         ]),
@@ -1487,6 +1500,7 @@ def draw_tab_smart_skills(config):
                 setattr(config, attr, current)
                 if current != previous:
                     Helper.log_event(message=f"{label} {'Enabled' if current else 'Disabled'}")
+                    config.save()
                 if tooltip and PyImGui.is_item_hovered():
                     PyImGui.set_tooltip(tooltip)
 


### PR DESCRIPTION
## Summary
- let Hero Helper recognize bows and other physical main-hand item types when maintaining Strength of Honor
- query the active weapon directly instead of assuming the first equipped-bag entry is the main hand
- save smart-skill checkbox changes immediately, including when Hero Helper itself is off
- preserve the existing shared hero command, recharge, energy, range, effect, and aftercast checks

## Mechanics
Guild Wars Wiki documents Strength of Honor as adding damage in melee, while the August 26, 2026 update says casters no longer drop it when the target changes away from a melee weapon. PvX build guidance also documents manually commanding and maintaining the skill with native hero casting disabled.

- https://wiki.guildwars.com/wiki/Strength_of_Honor
- https://wiki.guildwars.com/wiki/Feedback:Game_updates/20260826
- https://gwpvx.fandom.com/wiki/Build:Team_-_7_Hero_Paneptitude

## Validation
Offline:
- compiled the changed widget and focused test file
- 10 focused behavioral tests passed, covering bow-to-smartcast-to-manual-command flow, every supported physical item type, wand and dead-player rejection, shared cast rejection, fallback classification, and immediate toggle persistence
- PR runtime file matches the installed candidate exactly

In game:
- user confirmed Hero Helper casts Strength of Honor on a bow-equipped player with this candidate