### PR TITLE
Use Can't Touch This as a refrain heartbeat

### DIFF
--- a/Py4GWCoreLib/Builds/Paragon/P_W/Defensive Refrain.py
+++ b/Py4GWCoreLib/Builds/Paragon/P_W/Defensive Refrain.py
@@ -53,16 +53,11 @@ class Paragon_Refrain(BuildMgr):
     (Mighty Throw and Motivation Support) on top of the original Defensive
     Refrain bar. The engine is Heroic Refrain: it is stacked on ourselves first
     so every copy we hand out is cast at the highest Leadership we can reach,
-    then spread across the party, and from then on "They're on Fire!" alone
-    renews it on everyone - a refrain is reapplied whenever a chant or shout
-    *ends* on its holder.
+    then spread across the party. The echoes are renewed either when "They're
+    on Fire!" expires normally or through the documented special case where
+    reapplying "Can't Touch This!" ends its existing copy on affected allies.
 
-    That mechanic is why almost every shout helper on this bar refuses to
-    recast while its own copy is still running: replacing a shout is inferred
-    not to end it, so an early recast would silently skip a party-wide refrain
-    renewal. That inference is unconfirmed in an injected client and is written
-    up on Command.Cant_Touch_This. It is
-    also why the spear attacks are clamped to spear range - which is the same
+    The spear attacks are clamped to spear range - which is the same
     1012 units as earshot, so staying in range to attack is the same thing as
     staying in range to renew.
     """
@@ -73,12 +68,11 @@ class Paragon_Refrain(BuildMgr):
             required_primary=Profession.Paragon,
             required_secondary=Profession.Warrior,
             template_code="OQGkUNlnpiy0ZNQYPWNm72G4VhoH",
-            # The three skills every PvX variant of this build carries. Keeping
-            # the gate at three is what lets one class match the original bar,
-            # the Mighty Throw variant and the Motivation Support variant.
+            # Both supported refrain engines share Heroic Refrain and the core
+            # defensive shout. ScoreMatch below additionally requires either
+            # the traditional ToF heartbeat or the CTT reapplication heartbeat.
             required_skills=[
                 Heroic_Refrain_ID,
-                Theyre_on_Fire_ID,
                 Theres_Nothing_to_Fear_ID,
             ],
             # Everything here is driven below. That is not optional: declaring a
@@ -87,6 +81,7 @@ class Paragon_Refrain(BuildMgr):
             optional_skills=[
                 Save_Yourselves_luxon_ID,
                 Save_Yourselves_kurzick_ID,
+                Theyre_on_Fire_ID,
                 Anthem_of_Flame_ID,
                 Hasty_Refrain_ID,
                 Never_Surrender_ID,
@@ -133,6 +128,18 @@ class Paragon_Refrain(BuildMgr):
         # closest - pick the target that dies soonest.
         self.spear_target_type = "EnemyInjured"
 
+    def ScoreMatch(self, current_primary=None, current_secondary=None, current_skills=None):
+        score = super().ScoreMatch(current_primary, current_secondary, current_skills)
+        if score < 0:
+            return score
+
+        if current_skills is None:
+            current_skills = self._get_current_skills()
+        heartbeat_skills = {Theyre_on_Fire_ID, Cant_Touch_This_ID}
+        if not heartbeat_skills.intersection(current_skills):
+            return -1
+        return score
+
     def _run_upkeep(self):
         """Refrain maintenance. Runs in and out of combat.
 
@@ -154,6 +161,13 @@ class Paragon_Refrain(BuildMgr):
         # Aggressive Refrain is self-only and is maintained by the same expiring
         # shouts as the party refrains.
         if self.IsSkillEquipped(Aggressive_Refrain_ID) and (yield from self.skillbook.Paragon.Leadership.Aggressive_Refrain()):
+            return True
+
+        # Reapplying CTT ends its existing party shout and renews Heroic
+        # Refrain and the other maintainable echoes on each affected ally.
+        if self.IsSkillEquipped(Cant_Touch_This_ID) and (
+            yield from self.skillbook.Paragon.Command.Cant_Touch_This(maintain_refrains=True)
+        ):
             return True
 
         if self.IsSkillEquipped(Anthem_of_Flame_ID) and (yield from self.skillbook.Paragon.Leadership.Anthem_of_Flame()):
@@ -191,8 +205,8 @@ class Paragon_Refrain(BuildMgr):
         if self.IsSkillEquipped(Energizing_Finale_ID) and (yield from self.skillbook.Paragon.Motivation.Energizing_Finale()):
             return True
 
-        # Burning Refrain and Blazing Finale both pay off through "They're on
-        # Fire!", which is permanently up on this bar.
+        # Burning Refrain and Blazing Finale pay off most on the traditional
+        # "They're on Fire!" variant, but remain valid maintainable echoes.
         if self.IsSkillEquipped(Burning_Refrain_ID) and (yield from self.skillbook.Paragon.Motivation.Burning_Refrain()):
             return True
 
@@ -230,12 +244,6 @@ class Paragon_Refrain(BuildMgr):
             return True
 
         if self.IsSkillEquipped(Never_Surrender_ID) and (yield from self.skillbook.Paragon.Motivation.Never_Surrender()):
-            return True
-
-        # min_remaining_ms=0: the helper's default lets it recast with 1.5s
-        # still on the clock, which on this bar would throw away a refrain
-        # renewal every single time.
-        if self.IsSkillEquipped(Cant_Touch_This_ID) and (yield from self.skillbook.Paragon.Command.Cant_Touch_This(min_remaining_ms=0)):
             return True
 
         if self.IsSkillEquipped(Protectors_Defense_ID) and (yield from self.skillbook.Warrior.NoAttribute.Protectors_Defense()):

--- a/Py4GWCoreLib/Builds/Skills/paragon/Command.py
+++ b/Py4GWCoreLib/Builds/Skills/paragon/Command.py
@@ -25,43 +25,35 @@ class Command:
     #endregion
 
     #region C
-    def Cant_Touch_This(self, *, min_remaining_ms: int = 1500) -> BuildCoroutine:
-        """Anti-touch party shout.
+    def Cant_Touch_This(
+        self,
+        *,
+        maintain_refrains: bool = False,
+        min_remaining_ms: int = 1500,
+    ) -> BuildCoroutine:
+        """Anti-touch party shout and optional refrain-renewal heartbeat.
 
-        min_remaining_ms is how much of the running shout we are willing to
-        throw away by recasting early. Callers maintaining refrains should
-        pass 0.
-
-        Inferred, not confirmed in an injected client: a shout replaced before
-        it expires is believed not to fire the "a chant or shout ends" trigger
-        that reapplies an echo, so recasting early would silently skip a refrain
-        renewal for the whole party. What the shipped data actually states is
-        only the positive half - skill_descriptions.json describes a refrain as
-        renewed "whenever a chant or shout ends on that ally". The rest comes
-        from the PvX build notes. Every "let it expire first" guard on the
-        Paragon refrain bar rests on this, so it is the one assumption to settle
-        first if the rotation misbehaves in game.
+        Guild Wars treats this shout specially: reapplying it ends the existing
+        copy first, which triggers echoes. With its current 10-second recharge,
+        an HR bar can therefore cast it whenever ready even though the shout's
+        nominal duration is 20 seconds. Other callers retain the conservative
+        combat-only behavior and may wait until the running copy is nearly over.
         """
         cant_touch_this_id: int = Skill.GetID("Cant_Touch_This")
         player_agent_id = Player.GetAgentID()
 
         if not self.build.IsSkillEquipped(cant_touch_this_id):
             return False
-        if not self.build.IsInAggro():
+        if not maintain_refrains and not self.build.IsInAggro():
             return False
 
         if Routines.Checks.Agents.HasEffect(player_agent_id, cant_touch_this_id):
-            if min_remaining_ms <= 0:
-                # Presence is authoritative, the remaining time is not:
-                # GetEffectTimeRemaining only scans the effect list while
-                # HasEffect also accepts the buff list, so a shout reported as a
-                # buff reads 0 here. A caller asking us never to clip the shout
-                # would then clip it on every recharge - the exact failure this
-                # parameter exists to prevent.
-                return False
-            remaining_ms = int(GLOBAL_CACHE.Effects.GetEffectTimeRemaining(player_agent_id, cant_touch_this_id) or 0)
-            if remaining_ms > min_remaining_ms:
-                return False
+            if not maintain_refrains:
+                if min_remaining_ms <= 0:
+                    return False
+                remaining_ms = int(GLOBAL_CACHE.Effects.GetEffectTimeRemaining(player_agent_id, cant_touch_this_id) or 0)
+                if remaining_ms > min_remaining_ms:
+                    return False
 
         return (yield from self.build.CastSkillID(
             skill_id=cant_touch_this_id,


### PR DESCRIPTION
## Summary

- treat `Can't Touch This!` as an alternative Heroic Refrain heartbeat after its Aug. 26 recharge reduction to 10 seconds
- allow the Paragon refrain contract to match bars with Heroic Refrain, There's Nothing to Fear, and either `They're on Fire!` or `Can't Touch This!`
- add an explicit maintenance mode that reapplies CTT whenever ready in and out of combat; generic CTT callers keep their existing conservative combat-only behavior

## Mechanics

Guild Wars Wiki documents that reapplying `Can't Touch This!` ends its existing copy and triggers echoes. The Aug. 26, 2026 update reduced its recharge from 20 seconds to 10 seconds, making it a practical replacement heartbeat for refrain bars.

## Validation

- changed Python files compile
- local focused Paragon handler tests pass
- combined exact-bar release-candidate suite passes 15 tests
- in-game validation confirmed the combined local build uses the new bar

Local test artifacts are intentionally not included in this PR.