### PR TITLE
Use Aria chants in the Heroic Refrain rotation

### DIFF
--- a/Py4GWCoreLib/Builds/Paragon/P_W/Defensive Refrain.py
+++ b/Py4GWCoreLib/Builds/Paragon/P_W/Defensive Refrain.py
@@ -23,6 +23,8 @@ Ebon_Battle_Standard_of_Wisdom_ID = Skill.GetID("Ebon_Battle_Standard_of_Wisdom"
 Ebon_Battle_Standard_of_Honor_ID = Skill.GetID("Ebon_Battle_Standard_of_Honor")
 Protectors_Defense_ID = Skill.GetID("Protectors_Defense")
 Cant_Touch_This_ID = Skill.GetID("Cant_Touch_This")
+Aria_of_Zeal_ID = Skill.GetID("Aria_of_Zeal")
+Aria_of_Restoration_ID = Skill.GetID("Aria_of_Restoration")
 Make_Your_Time_ID = Skill.GetID("Make_Your_Time")
 Angelic_Protection_ID = Skill.GetID("Angelic_Protection")
 
@@ -99,6 +101,8 @@ class Paragon_Refrain(BuildMgr):
                 Ebon_Battle_Standard_of_Honor_ID,
                 Protectors_Defense_ID,
                 Cant_Touch_This_ID,
+                Aria_of_Zeal_ID,
+                Aria_of_Restoration_ID,
                 Make_Your_Time_ID,
                 Angelic_Protection_ID,
                 Mighty_Throw_ID,
@@ -213,6 +217,12 @@ class Paragon_Refrain(BuildMgr):
         # they are also the bar's energy engine, since Leadership refunds energy
         # per ally a shout or chant affects.
         if self.IsSkillEquipped(Theres_Nothing_to_Fear_ID) and (yield from self.skillbook.Any.NoAttribute.Theres_Nothing_to_Fear()):
+            return True
+
+        if self.IsSkillEquipped(Aria_of_Zeal_ID) and (yield from self.skillbook.Paragon.Motivation.Aria_of_Zeal()):
+            return True
+
+        if self.IsSkillEquipped(Aria_of_Restoration_ID) and (yield from self.skillbook.Paragon.Motivation.Aria_of_Restoration()):
             return True
 
         # Save Yourselves outranks the skills that charge it: when it is already

--- a/Py4GWCoreLib/Builds/Skills/paragon/Motivation.py
+++ b/Py4GWCoreLib/Builds/Skills/paragon/Motivation.py
@@ -16,6 +16,31 @@ class Motivation:
     def __init__(self, build: BuildMgr) -> None:
         self.build: BuildMgr = build
 
+    def _cast_combat_aria(self, skill_id: int) -> BuildCoroutine:
+        """Use a spell-triggered party chant without clipping our own copy."""
+        player_agent_id = Player.GetAgentID()
+
+        if not self.build.IsSkillEquipped(skill_id):
+            return False
+        if not self.build.IsInAggro():
+            return False
+        if Routines.Checks.Agents.HasEffect(player_agent_id, skill_id):
+            return False
+
+        return (yield from self.build.CastSkillID(
+            skill_id=skill_id,
+            log=False,
+            aftercast_delay=250,
+        ))
+
+    #region A
+    def Aria_of_Restoration(self) -> BuildCoroutine:
+        return (yield from self._cast_combat_aria(Skill.GetID("Aria_of_Restoration")))
+
+    def Aria_of_Zeal(self) -> BuildCoroutine:
+        return (yield from self._cast_combat_aria(Skill.GetID("Aria_of_Zeal")))
+    #endregion
+
     #region B
     def Blazing_Finale(self, *, max_target_range: float | None = None) -> BuildCoroutine:
         return (yield from self.build.SpreadEchoToAlly(Skill.GetID("Blazing_Finale"), max_range=max_target_range))


### PR DESCRIPTION
## Summary

- register Aria of Zeal and Aria of Restoration with the Heroic Refrain build contract
- cast both party chants during combat, after There's Nothing to Fear and before the rest of the defensive/offensive rotation
- avoid replacing the Paragon's still-active copy, while allowing a fresh cast after it is consumed or expires

The other skills on the tested bar—Heroic Refrain, There's Nothing to Fear, Bladeturn Refrain, Mending Refrain, and Hasty Refrain—were already covered by the existing controller. This PR only fills the two missing Aria calls.

## Validation

- changed Python files compile
- 6 existing Paragon atomic-handler tests pass
- combined exact eight-skill bar suite passes 15 tests
- in-game validation confirmed the combined local build