### PR TITLE
Wait for max Heroic Refrain before spreading echoes

### DIFF
--- a/Py4GWCoreLib/Builds/Paragon/P_W/Defensive Refrain.py
+++ b/Py4GWCoreLib/Builds/Paragon/P_W/Defensive Refrain.py
@@ -142,8 +142,15 @@ class Paragon_Refrain(BuildMgr):
         # The elite, and the reason for the bar, must be first. Its helper casts
         # on self until the Leadership bootstrap reaches 20, then walks the
         # party. Refrains cast before that bootstrap would use the lower rank.
-        if self.IsSkillEquipped(Heroic_Refrain_ID) and (yield from self.skillbook.Paragon.Leadership.Heroic_Refrain()):
-            return True
+        if self.IsSkillEquipped(Heroic_Refrain_ID):
+            if (yield from self.skillbook.Paragon.Leadership.Heroic_Refrain()):
+                return True
+
+            # Heroic_Refrain returns False both when bootstrap is complete and
+            # when the second self cast is merely recharging. Only the live
+            # rank-20 postcondition permits lower-rank refrains to be spread.
+            if not self.skillbook.Paragon.Leadership.IsHeroicRefrainSelfReady():
+                return True
 
         # Spread every equipped party refrain immediately after Heroic Refrain,
         # in or out of combat. Entering combat must not postpone an incomplete

--- a/Py4GWCoreLib/Builds/Skills/paragon/Leadership.py
+++ b/Py4GWCoreLib/Builds/Skills/paragon/Leadership.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from Py4GWCoreLib.BuildMgr import BuildCoroutine
-from Py4GWCoreLib import GLOBAL_CACHE, Player, Routines
+from Py4GWCoreLib import Player, Routines
 from Py4GWCoreLib.Skill import Skill
 
 if TYPE_CHECKING:
@@ -24,30 +24,17 @@ class Leadership:
         leadership = next((attribute for attribute in attributes if attribute.GetName() == "Leadership"), None)
         return int(getattr(leadership, "level", 0) or 0)
 
-    @staticmethod
-    def _get_effect_attribute_level(skill_id: int) -> int:
+    def IsHeroicRefrainSelfReady(self) -> bool:
+        """Return whether the self copy has completed the +4 bootstrap."""
+        heroic_refrain_id = Skill.GetID("Heroic_Refrain")
         player_agent_id = Player.GetAgentID()
-        effect = next(
-            (
-                item
-                for item in GLOBAL_CACHE.Effects.GetEffects(player_agent_id)
-                if item.skill_id == skill_id
-            ),
-            None,
+        return (
+            Routines.Checks.Agents.HasEffect(player_agent_id, heroic_refrain_id)
+            and self._get_leadership_level() >= 20
         )
-        return int(getattr(effect, "attribute_level", 0) or 0)
 
     def _heroic_refrain_needs_self_bootstrap(self, heroic_refrain_id: int) -> bool:
-        player_agent_id = Player.GetAgentID()
-        if not Routines.Checks.Agents.HasEffect(player_agent_id, heroic_refrain_id):
-            return True
-
-        leadership_level = self._get_leadership_level()
-        if leadership_level >= 20:
-            return False
-
-        cast_level = self._get_effect_attribute_level(heroic_refrain_id)
-        return cast_level > 0 and leadership_level > cast_level
+        return not self.IsHeroicRefrainSelfReady()
 
     #region H
     def Heroic_Refrain(self) -> BuildCoroutine:
@@ -65,14 +52,6 @@ class Leadership:
                 log=False,
                 aftercast_delay=250,
             ))
-        if not Routines.Checks.Agents.HasEffect(player_agent_id, heroic_refrain_id):
-            return (yield from self.build.CastSkillIDAndRestoreTarget(
-                skill_id=heroic_refrain_id,
-                target_agent_id=player_agent_id,
-                log=False,
-                aftercast_delay=250,
-            ))
-
         target_agent_id = self.build.ResolveAllyTarget(
             heroic_refrain_id,
             heroic_refrain,


### PR DESCRIPTION
## Summary
- require the self Heroic Refrain copy and live Leadership 20 before party distribution
- distinguish a recharging second self-cast from completed bootstrap
- hold Mending, Bladeturn, Hasty, and the rest of the rotation until the +4 copy is active

## Why
With the standard 16 Leadership setup, the first self-cast gives +3 and raises Leadership to 19. While the second cast was recharging, Heroic_Refrain() returned false and the controller treated that as completed setup, so lower-rank refrains could be applied. Their shout-triggered renewal preserves those lower-rank copies instead of upgrading them.

## Verification
- both changed Python files compile
- three focused local behavioral checks passed (not included in the PR): rank-20 readiness, recharge does not fall through to party targeting, and recharge blocks other refrains
- confirmed in game after a full core-module reload: HR completes both self-casts before refrain distribution begins