### PR TITLE
Use live effects for party hero targeting

### DIFF
--- a/Py4GWCoreLib/HeroAI/utils.py
+++ b/Py4GWCoreLib/HeroAI/utils.py
@@ -123,6 +123,14 @@ def CheckForEffect(agent_id, skill_id, cached_data : Optional[CacheData] = None)
         # Self-upkeep should use live local effects rather than shared-memory party
         # state, which can lag and suppress recasts of expired buffs.
         return GLOBAL_CACHE.Effects.HasEffect(agent_id, skill_id)
+
+    # Heroes are locally observable party members. Their synthetic shared-memory
+    # slots can lag, disappear, or retain an expired buff for a few frames; using
+    # that copy can permanently remove a hero from buff targeting. Read the live
+    # effect table for party heroes just as we do for the local player.
+    for hero in GLOBAL_CACHE.Party.GetHeroes() or []:
+        if int(getattr(hero, "agent_id", 0) or 0) == int(agent_id):
+            return GLOBAL_CACHE.Effects.HasEffect(agent_id, skill_id)
     
     for acc in cached_data.party:
         if acc.IsSlotActive and acc.AgentData.AgentID == agent_id and SameMapOrPartyAsAccount(acc) and acc.AgentPartyData.PartyID == cached_data.party.party_id:


### PR DESCRIPTION
## Summary

- read locally observable party-hero effects from the live client instead of synthetic shared-memory hero slots
- prevent missing or stale hero slots from falsely reporting a buff and excluding that hero from ally targeting
- preserve existing shared-memory handling for remote accounts and conservative fallbacks for spirits, pets, friendly NPCs, and arbitrary allies

## Evidence

The issue reproduced as a stable party-slot cutoff: the player and first five heroes received Heroic Refrain, Mending Refrain, Bladeturn Refrain, and Hasty Refrain while the last two nearby heroes received none. The selector has no six-member cap, the heroes were visibly in the group, and the cutoff persisted beyond skill recharge. After installing this candidate, the same in-game behavior was confirmed working.

## Testing

- `python -m py_compile Py4GWCoreLib/HeroAI/utils.py`
- 4 focused local regressions passed: uncached hero eligibility, active-effect filtering, stale shared-copy override, and unchanged conservative NPC fallback
- focused tests are intentionally not included in this source-only PR