### PR TITLE
Fix Salvage Kit model IDs

### DIFF
--- a/Py4GWCoreLib/enums_src/Model_enums.py
+++ b/Py4GWCoreLib/enums_src/Model_enums.py
@@ -1607,7 +1607,7 @@ class ModelID(IntEnum):
     Rune_Of_Holding = 2988
     Rune_Of_Superior_Vigor = 5551
     Sack_Of_Random_Junk = 34213
-    Salvage_Kit = 2993
+    Salvage_Kit = 2992
     Salvage_Kit_preSearing = 2993
     Sandblasted_Lodestone = 1584
     Sapphire = 938

--- a/Py4GWCoreLib/routines_src/behaviourtrees_src/items.py
+++ b/Py4GWCoreLib/routines_src/behaviourtrees_src/items.py
@@ -2149,6 +2149,11 @@ class BTItems:
           UserDescription: Use this when you want a BT step that manages salvage UI and progress automatically for one item.
           Notes: Stores runtime state in the blackboard, supports expert or lesser kits, and returns running while the salvage flow is in progress.
         """
+        lesser_kit_model_ids = (
+            ModelID.Salvage_Kit,
+            ModelID.Salvage_Kit_preSearing,
+        )
+
         def _reset_state(node: BehaviorTree.Node):
             node.blackboard.pop(state_key, None)
 
@@ -2192,7 +2197,7 @@ class BTItems:
             return min(expert_kits, key=lambda kit: kit.uses).id
 
         def _get_lesser_salvage_kit() -> int:
-            preferred = _resolve_preferred_kit((ModelID.Salvage_Kit,))
+            preferred = _resolve_preferred_kit(lesser_kit_model_ids)
             if preferred > 0:
                 return preferred
 
@@ -2204,7 +2209,7 @@ class BTItems:
                 if item is not None
                 and item.is_valid
                 and item.is_salvage_kit
-                and item.model_id == ModelID.Salvage_Kit
+                and item.model_id in lesser_kit_model_ids
             ]
             if not lesser_kits:
                 return 0
@@ -2312,7 +2317,7 @@ class BTItems:
                 kit = ItemSnapshot.from_item_id(kit_id)
                 if kit_id <= 0 or (
                     kit is None
-                    or kit.model_id == ModelID.Salvage_Kit
+                    or kit.model_id in lesser_kit_model_ids
                     and (item.rarity > Rarity.White and not item.is_identified)
                 ):
                     _debug(

--- a/Sources/frenkeyLib/ItemHandling/BTNodes.py
+++ b/Sources/frenkeyLib/ItemHandling/BTNodes.py
@@ -709,6 +709,11 @@ class BTNodes:
               UserDescription: Use this when you want a BT step that manages salvage UI and progress automatically for one item.
               Notes: Stores runtime state in the blackboard, supports expert or lesser kits, and returns running while the salvage flow is in progress.
             """
+            lesser_kit_model_ids = (
+                ModelID.Salvage_Kit,
+                ModelID.Salvage_Kit_preSearing,
+            )
+
             def _reset_state(node: BehaviorTree.Node):
                 node.blackboard.pop(state_key, None)
 
@@ -746,12 +751,20 @@ class BTNodes:
                 return min(expert_kits, key=lambda k: k.uses).id
             
             def _get_lesser_salvage_kit() -> int:
-                preferred = _resolve_preferred_kit((ModelID.Salvage_Kit,))
+                preferred = _resolve_preferred_kit(lesser_kit_model_ids)
                 if preferred > 0:
                     return preferred
 
                 inventory_snapshot = ItemSnapshot.get_inventory_snapshot(Bag.Backpack, Bag.Bag_2)
-                lesser_kits = [i for bag in inventory_snapshot.values() for i in bag.values() if i is not None and i.is_valid and i.is_salvage_kit and i.model_id == ModelID.Salvage_Kit]
+                lesser_kits = [
+                    item
+                    for bag in inventory_snapshot.values()
+                    for item in bag.values()
+                    if item is not None
+                    and item.is_valid
+                    and item.is_salvage_kit
+                    and item.model_id in lesser_kit_model_ids
+                ]
                 
                 if not lesser_kits:
                     return 0
@@ -859,7 +872,11 @@ class BTNodes:
                         kit_id = _get_upgrade_salvage_kit()
 
                     kit = ItemSnapshot.from_item_id(kit_id)
-                    if kit_id <= 0 or (kit is None or kit.model_id == ModelID.Salvage_Kit and (item.rarity > Rarity.White and not item.is_identified)):
+                    if kit_id <= 0 or (
+                        kit is None
+                        or kit.model_id in lesser_kit_model_ids
+                        and (item.rarity > Rarity.White and not item.is_identified)
+                    ):
                         _debug(
                             f"Failed to resolve valid salvage kit for item={item.id} mode={mode.name}. "
                             f"kit_id={kit_id} kit_model={(kit.model_id if kit else 'None')} "


### PR DESCRIPTION
I noticed an issue with the Salvage Kit IDs.

There are two different basic Salvage Kits:

- Normal Salvage Kit: `2992`
- Pre-Searing Salvage Kit: `2993`

In `Model_enums.py`, the normal Salvage Kit was changed from `2992` to `2993`, which made both entries use the same ID. Because of that, some shared salvage code can miss the normal `2992` kit or treat the two kits as if they were the same.

The change in `Model_enums.py` puts the normal Salvage Kit back to `2992` and keeps the pre-Searing kit at `2993`.

There was one other thing to account for. Since both entries had been using the same ID, a couple of the shared salvage checks were also relying on that without meaning to.

The changes in `items.py` and `BTNodes.py` make those checks support both kits directly, so normal and pre-Searing salvage continue to work after the IDs are separated again.

So the three changes together:

- restore the correct ID for each Salvage Kit
- make the shared salvage code recognize both kits properly
- remove the need for both kits to share the same ID