### PR TITLE
Fix duplicate coroutine removal crash in FSM

### DIFF
--- a/Py4GWCoreLib/py4gwcorelib_src/FSM.py
+++ b/Py4GWCoreLib/py4gwcorelib_src/FSM.py
@@ -567,7 +567,10 @@ class FSM:
             try:
                 next(routine)
             except StopIteration:
-                self.managed_coroutines.remove(routine)
+                try:
+                    self.managed_coroutines.remove(routine)
+                except ValueError:
+                    pass
             except Exception as e:
                 state_name = self.current_state.name if self.current_state else "Unknown"
                 tb = traceback.format_exc()


### PR DESCRIPTION
Removing a finished coroutine twice (e.g. after a state reset) could raise a crash. Added a guard, same pattern already used elsewhere in this file.