### PR TITLE
Fix incorrect item types for gift items

### DIFF
--- a/Sources/frenkeyLib/ItemHandling/Items/items.json
+++ b/Sources/frenkeyLib/ItemHandling/Items/items.json
@@ -92,24 +92,6 @@
             "sub_category": null,
             "wiki_url": "https://wiki.guildwars.com/wiki/Birthday_Present"
         },
-        "31148": {
-            "acquisition": "No data added yet",
-            "attributes": [],
-            "category": null,
-            "common_salvage": null,
-            "description": "",
-            "item_type": "Present",
-            "model_file_id": -1,
-            "model_id": 31148,
-            "name": "Gift of the Traveler",
-            "name_encoded": "",
-            "nick_index": null,
-            "profession": null,
-            "rare_salvage": null,
-            "skin": "Gift of the Traveler.png",
-            "sub_category": null,
-            "wiki_url": "https://wiki.guildwars.com/wiki/Gift_of_the_Traveler"
-        },
         "36667": {
             "acquisition": "No data added yet",
             "attributes": [],
@@ -415,42 +397,6 @@
             "skin": "Zaishen Strongbox.png",
             "sub_category": null,
             "wiki_url": "https://wiki.guildwars.com/wiki/Strategist%27s_Zaishen_Strongbox"
-        },
-        "28434": {
-            "acquisition": "No data added yet",
-            "attributes": [],
-            "category": null,
-            "common_salvage": null,
-            "description": "",
-            "item_type": "Present",
-            "model_file_id": -1,
-            "model_id": 28434,
-            "name": "Trick-or-Treat Bag",
-            "name_encoded": "",
-            "nick_index": null,
-            "profession": null,
-            "rare_salvage": null,
-            "skin": "Trick-or-Treat Bag.png",
-            "sub_category": null,
-            "wiki_url": "https://wiki.guildwars.com/wiki/Trick-or-Treat_Bag"
-        },
-        "21491": {
-            "acquisition": "No data added yet",
-            "attributes": [],
-            "category": null,
-            "common_salvage": null,
-            "description": "",
-            "item_type": "Present",
-            "model_file_id": -1,
-            "model_id": 21491,
-            "name": "Wintersday Gift",
-            "name_encoded": "",
-            "nick_index": null,
-            "profession": null,
-            "rare_salvage": null,
-            "skin": "Wintersday Gift.png",
-            "sub_category": null,
-            "wiki_url": "https://wiki.guildwars.com/wiki/Wintersday_Gift"
         }
     },
     "Salvage": {


### PR DESCRIPTION
I noticed that Wintersday Gift, Trick-or-Treat Bag, and Gift of the Traveler were each showing up twice in the shared item list. Each one had both a Present entry and a Usable entry.

I tested all three items in the game to see which type they actually use, and all three showed up as Usable.

Because of that, the extra Present entries were incorrect and were causing these items to appear twice in searches. This change removes those incorrect entries and keeps the correct Usable entries.

After making the change, I tested all three items again by searching for both their names and model IDs. Each one now appears only once, as expected.